### PR TITLE
Add a Travis-CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+script:
+  - py.test


### PR DESCRIPTION
To avoid regressions, it's helpful to make use of some CI
environment. Travis-CI is a good option, and this recipe adds
testing on a number of different Python versions.

Signed-off-by: Cleber Rosa <crosa@redhat.com>