### PR TITLE
Adding an '-extract-to' option to specify where to extract an ISO to

### DIFF
--- a/tools/pycdlib-extract-files
+++ b/tools/pycdlib-extract-files
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (C) 2018  Chris Lalancette <clalancette@gmail.com>
 
@@ -43,6 +43,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument('-path-type', help='Which path type to use for extraction', action='store', choices=['iso', 'joliet', 'rockridge', 'udf'], default='iso')
     parser.add_argument('-start-path', help='Path on ISO to start extraction from', action='store', default='/')
+    parser.add_argument('-extract-to', help='Path to extract ISO contents to', action='store', default='.')
     parser.add_argument('iso', help='ISO to open', action='store')
     return parser.parse_args()
 
@@ -89,7 +90,7 @@ def main():
         print(relname)
         if dir_record.is_dir():
             if relname != '':
-                os.makedirs(relname)
+                os.makedirs(os.path.join(args.extract_to, relname))
             child_lister = iso.list_children(**{pathname: ident_to_here})
 
             for child in child_lister:
@@ -98,7 +99,7 @@ def main():
                 dirs.append(child)
         else:
             if dir_record.rock_ridge is None or not dir_record.rock_ridge.is_symlink():
-                iso.get_file_from_iso(relname, **{pathname: ident_to_here})
+                iso.get_file_from_iso(os.path.join(args.extract_to, relname), **{pathname: ident_to_here})
 
     iso.close()
     return 0


### PR DESCRIPTION
This would give the user the option of extracting an ISO to a specific directory. I also changed the "shebang" so the script would work in a virtualenv environment.