### PR TITLE
Allow specifying a read-only mode for open()

### DIFF
--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -3872,7 +3872,7 @@ class PyCdlib(object):
 
         self._initialized = True
 
-    def open(self, filename):
+    def open(self, filename, mode='r+b'):
         # type: (str) -> None
         '''
         Open up an existing ISO for inspection and modification.
@@ -3885,7 +3885,7 @@ class PyCdlib(object):
         if self._initialized:
             raise pycdlibexception.PyCdlibInvalidInput('This object already has an ISO; either close it or create a new object')
 
-        fp = open(filename, 'r+b')
+        fp = open(filename, mode)
         self._managing_fp = True
         try:
             self._open_fp(fp)


### PR DESCRIPTION
Just a suggestion.  You can achieve the same effect by opening the file first, and using the open_fp() method, and supplying any arguments to that, but it's an extra line.  I frequently need to open ISO images I don't have write-access to.