### PR TITLE
Fix IndexError when attempting to get rr record from empty dir

### DIFF
--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -736,6 +736,12 @@ class PyCdlib(object):
             child = None
 
             thelist = entry.rr_children
+            # The list could be empty because we don't store dot or dotdot
+            # entries in Rock Ridge.  If that is the case, just get out and
+            # fail since we definitely didn't find what we were looking for.
+            if not thelist:
+                break
+
             lo = 0
             hi = len(thelist)
             while lo < hi:

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -6489,3 +6489,18 @@ def test_new_rr_file_mode_not_rr():
     assert(str(excinfo.value) == 'Cannot fetch a rr_path from a non-Rock Ridge ISO')
 
     iso.close()
+
+def test_new_rr_empty_dir_get_record():
+    # Create a new ISO.
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.09')
+
+    # Add new directory.
+    iso.add_directory('/DIR1', rr_name='dir1')
+
+    # Now try to get a non-existent record in that directory.
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+        rec = iso.get_record(rr_path='/dir1/foo')
+    assert(str(excinfo.value) == 'Could not find path')
+
+    iso.close()


### PR DESCRIPTION
I ran into this earlier today.  It looks like the culprit was on line 754:

`tmpchild = thelist[index]`

Fixes #35 