### PR TITLE
Create and Use a WindowsRawDevice Object on Windows Raw Devices

### DIFF
--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -48,6 +48,7 @@ from pycdlib import pycdlibexception
 from pycdlib import pycdlibio
 from pycdlib import udf as udfmod
 from pycdlib import utils
+from pycdlib import windows
 
 # For mypy annotations
 if False:  # pylint: disable=using-constant-test
@@ -2363,6 +2364,11 @@ class PyCdlib(object):
         Returns:
          Nothing.
         '''
+        if fp.name.startswith("\\\\.\\"):
+            # Windows Raw Devices don't have vital information and need to
+            # seek aligned with the sector size, this wrapper bypasses this.
+            fp = windows.WindowsRawDevice(fp)
+
         if hasattr(fp, 'mode') and 'b' not in fp.mode:
             raise pycdlibexception.PyCdlibInvalidInput("The file to open must be in binary mode (add 'b' to the open flags)")
 

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -1033,12 +1033,7 @@ class PyCdlib(object):
     def _get_iso_size(self):
         # type: () -> int
         '''
-        An internal method to get the ISO size.  This is more complicated than
-        you might think due to Windows.  There, if you try to open a 'raw'
-        device, you can only seek on 2048-byte boundaries (and you can't
-        seek to the END).  We first try to seek to the end, which is the most
-        efficient way to do it.  If that fails, we fall back to seeking and
-        reading until we get empty data, which signals the end of the ISO.
+        An internal method to get the ISO size.
 
         Parameters:
          None.
@@ -1046,40 +1041,10 @@ class PyCdlib(object):
          The size of the ISO in bytes.
         '''
         old = self._cdfp.tell()
-        try:
-            self._cdfp.seek(0, os.SEEK_END)
-            ret = self._cdfp.tell()
-            self._cdfp.seek(old)
-            return ret
-        except OSError:
-            pass
-
-        # When reading a raw Windows device, we cannot seek to the end to find
-        # the length.  Instead, we start right at the beginning of the ISO and
-        # seek by 1MB at a time to find the end of it.  This meets the Windows
-        # requirement that we seek by a 512-byte aligned value while also
-        # having decent performance.  Once we find the 1MB boundary, we back
-        # up and find the real 2048-byte boundary.
-        bs = 1048576
-        one_mb_block = 0
-        while True:
-            self._cdfp.seek(one_mb_block * bs)
-            data = self._cdfp.read(1)
-            if len(data) != 1:
-                break
-            one_mb_block += 1
-        if one_mb_block > 0:
-            one_mb_block -= 1
-        extent = (one_mb_block * bs) // 2048
-        while True:
-            self._cdfp.seek(extent * 2048)
-            data = self._cdfp.read(2048)
-            if len(data) != 2048:
-                break
-            extent += 1
-
+        self._cdfp.seek(0, os.SEEK_END)
+        ret = self._cdfp.tell()
         self._cdfp.seek(old)
-        return extent * 2048
+        return ret
 
     def _walk_directories(self, vd, extent_to_ptr, extent_to_inode,
                           path_table_records):

--- a/pycdlib/windows.py
+++ b/pycdlib/windows.py
@@ -1,0 +1,113 @@
+import math
+import os
+from typing import IO, Optional
+
+
+class WindowsRawDevice:
+    """
+    Windows Raw Device Blocks have extremely strict seeking, ensuring that
+    seeks are to the start of each sector (aka divisible by 512).
+    os.SEEK_END doesn't work either for some reason.
+    Both of these features are crucial to be able to efficiently scrub data
+    back and forth in a non dominant order.
+
+    This class gets around these restrictions in a surprisingly simple way.
+    It's quite simple you would kind of expect it to be supported by default.
+
+    To access the original IO object use self.device. It's recommended to use
+    the re-implemented functions if available over the original functions.
+    """
+
+    def __init__(self, device: IO):
+        self.device = device
+        self.length = None
+
+    def __len__(self) -> int:
+        """Get size via WMI if available, otherwise using seek & read scrubbing."""
+        if self.length is not None:
+            return self.length
+
+        try:
+            from wmi import WMI
+        except ImportError:
+            pass
+        else:
+            c = WMI()
+            win_device = "".join(filter(str.isalnum, self.device.name)) + ":"
+            drive = next(iter(c.Win32_CDROMDrive(Drive=win_device)), None)
+            if drive:
+                self.length = int(drive.size)
+                return self.length
+
+        old = self.tell()
+
+        bs = 1048576
+        one_mb_block = 0
+        while True:
+            self.seek(one_mb_block * bs)
+            data = self.read(1)
+            if len(data) != 1:
+                break
+            one_mb_block += 1
+        if one_mb_block > 0:
+            one_mb_block -= 1
+        extent = (one_mb_block * bs) // 2048
+        while True:
+            self.seek(extent * 2048)
+            data = self.read(2048)
+            if len(data) != 2048:
+                break
+            extent += 1
+
+        self.seek(old)
+        self.length = extent * 2048
+        return self.length
+
+    def read(self, size: int = -1) -> Optional[bytes]:
+        return self.device.read(size)
+
+    def tell(self) -> int:
+        return self.device.tell()
+
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        if whence == os.SEEK_CUR:
+            whence = self.tell()
+        elif whence == os.SEEK_END:
+            whence = len(self)
+
+        to = whence + offset
+        closest = self.align(to)  # get as close as we can while being aligned
+
+        # for some really odd system, sometimes even if your sector
+        # aligned it still fails. For example seeking to `7404431360 - 1` which
+        # when aligned resolves to `7404430848` fails, closest working position
+        # is `7404429312` which is 2048 bytes (4 sectors) behind it.
+        # Why? Is there some kind of 2nd alignment that needs to happen other than % 512?
+        # This code deals with this as best as it can.
+        fails = 0
+        while True:
+            try:
+                seek_to = closest - (512 * fails)
+                self.device.seek(seek_to)
+                break
+            except OSError:
+                fails += 1
+        self.read(to - closest + (512 * fails))
+
+        return to
+
+    @staticmethod
+    def align(size: int, to: int = 512) -> int:
+        """
+        Align size to the closest but floor mod `to` value.
+        Examples:
+            align(513)
+            >>>512
+            align(1023)
+            >>>512
+            align(1026)
+            >>>1024
+            align(12, 10)
+            >>>10
+        """
+        return math.floor(size / to) * to


### PR DESCRIPTION
This wraps the input fp, allowing manual overwrites to seek to deal with sector-aligned seeking.

I couldn't figure out a way to Inherit an IO object so that it's self.device isn't needed as I cannot find out how open() actually works, how it actually instantiates what it does.

It also deals with length using `wmi` for very quick speed if available, otherwise does it how the code was already handling it for Windows Raw Devices.

I tested it and it is working on Windows disc drives but it fails to do with parsing UDF descriptors.
I believe the issue is unrelated, or at least a windows-specific issue that we don't know why yet. It does seem to follow the prior code as you would expect, and could possibly be an issue specific to my disc for all I know. It seems to be doing some UDF parsing prior to it based on the heavy amount of os.SEEK_END being called prior to the error.

Even if not unrelated, its still fixing a ton of issues to do with Windows prior. See #50

The (should be unrelated) error stack trace:
```
>>> import pycdlib
>>> cdlib = pycdlib.PyCdlib()
>>> cdlib.open(r"\\.\D:")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\phoenix\Git\pycdlib\pycdlib\pycdlib.py", line 4242, in open
    self._open_fp(fp)
  File "C:\Users\phoenix\Git\pycdlib\pycdlib\pycdlib.py", line 2520, in _open_fp
    self._parse_udf_descriptors()
  File "C:\Users\phoenix\Git\pycdlib\pycdlib\pycdlib.py", line 2144, in _parse_udf_descriptors
    anchor_tag.parse(anchor_data, extent)
  File "C:\Users\phoenix\Git\pycdlib\pycdlib\udf.py", line 683, in parse
    self.tag_location) = struct.unpack_from(self.FMT, data, 0)
struct.error: unpack_from requires a buffer of at least 16 bytes for unpacking 16 bytes at offset 0 (actual buffer size is 0)
```