### PR TITLE
Add Full Support for Windows Raw Block Devices

### DIFF
--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -2276,10 +2276,11 @@ class PyCdlib(object):
         if hasattr(fp, 'mode') and 'b' not in fp.mode:
             raise pycdlibexception.PyCdlibInvalidInput("The file to open must be in binary mode (add 'b' to the open flags)")
 
-        if fp.name.startswith("\\\\.\\"):
-            fp_win = utils.Win32Device(fp.name)
-            fp.close()
-            fp = fp_win
+        # If this is a Windows platform, and the file-like object name starts
+        # with \\.\, this is a "raw" Windows device and we have to treat it
+        # specially.
+        if sys.platform == 'win32' and hasattr(fp, 'name') and fp.name.startswith("\\\\.\\"):
+            fp = utils.Win32RawDevice(fp.name)
 
         self._cdfp = fp
 

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -2276,6 +2276,11 @@ class PyCdlib(object):
         if hasattr(fp, 'mode') and 'b' not in fp.mode:
             raise pycdlibexception.PyCdlibInvalidInput("The file to open must be in binary mode (add 'b' to the open flags)")
 
+        if fp.name.startswith("\\\\.\\"):
+            fp_win = utils.Win32Device(fp.name)
+            fp.close()
+            fp = fp_win
+
         self._cdfp = fp
 
         # Get the Primary Volume Descriptor (pvd), the set of Supplementary

--- a/pycdlib/utils.py
+++ b/pycdlib/utils.py
@@ -20,22 +20,29 @@ Various utilities for PyCdlib.
 
 from __future__ import absolute_import
 
-try:
-    import cStringIO  # pylint: disable=import-error
-except ImportError:
-    pass
 import io
+import math
 import os
 import re
 import struct
 import sys
 import time
 
+if sys.platform == "win32":
+    import win32con
+    import win32file
+    import winioctlcon
+
+try:
+    import cStringIO  # pylint: disable=import-error
+except ImportError:
+    pass
+
 from pycdlib import pycdlibexception
 
 # For mypy annotations
 if False:  # pylint: disable=using-constant-test
-    from typing import BinaryIO, List, Tuple  # NOQA pylint: disable=unused-import
+    from typing import BinaryIO, List, Tuple, Optional  # NOQA pylint: disable=unused-import
 
 
 def swab_32bit(x):
@@ -426,3 +433,157 @@ def mangle_dir_for_iso9660(orig, iso_level):
     # sequence starting from 0.
 
     return truncate_basename(orig, iso_level, True)
+
+
+class Win32Device:
+    """
+    Class to read and seek a Windows Raw Device IO object without bother.
+    It deals with getting the full size, allowing full access to all sectors,
+    and alignment with the discs sector size.
+    """
+
+    def __init__(self, target):
+        # type: (str) -> None
+        self.target = target
+        self.sector_size = None
+        self.disc_size = None
+        self.position = 0
+
+        self.handle = self.get_handle()
+        self.geometry = self.get_geometry()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_, **__):
+        self.dispose()
+
+    def __len__(self) -> int:
+        return self.geometry[-2]
+
+    def dispose(self):
+        if self.handle != win32file.INVALID_HANDLE_VALUE:
+            win32file.CloseHandle(self.handle)
+
+    def get_target(self):
+        # type: () -> str
+        """Get UNC target name. Can be `E:` or `PhysicalDriveN`."""
+        target = self.target
+        if not target.startswith("\\\\.\\"):
+            target = rf"\\.\{target}"
+        return target
+
+    def get_handle(self):
+        # type: () -> int
+        """Get a direct handle to the raw UNC target, and unlock its IO capabilities."""
+        handle = win32file.CreateFile(
+            # https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
+            self.get_target(),  # target
+            win32con.MAXIMUM_ALLOWED,  # desired access
+            win32con.FILE_SHARE_READ | win32con.FILE_SHARE_WRITE,  # share mode, write needed
+            None,  # security attributes
+            win32con.OPEN_EXISTING,  # creation disposition
+            win32con.FILE_ATTRIBUTE_NORMAL,  # flags and attributes
+            None  # template file
+        )
+        if handle == win32file.INVALID_HANDLE_VALUE:
+            raise RuntimeError("Failed to obtain device handle...")
+        # elevate accessible sectors, without this the last 5 sectors (in my case) will not be readable
+        win32file.DeviceIoControl(handle, winioctlcon.FSCTL_ALLOW_EXTENDED_DASD_IO, None, None)
+        return handle
+
+    def get_geometry(self):
+        # type: () -> tuple[int, ...]
+        """
+        Retrieves information about the physical disk's geometry.
+        https://docs.microsoft.com/en-us/windows/win32/api/winioctl/ns-winioctl-disk_geometry_ex
+
+        Returns a tuple of:
+            Cylinders-Lo
+            Cylinders-Hi
+            Media Type
+            Tracks Per Cylinder
+            Sectors Per Track
+            Bytes Per Sector
+            Disk Size
+            Extra Data
+        """
+        return struct.unpack("8L", win32file.DeviceIoControl(
+            self.handle,  # handle
+            winioctlcon.IOCTL_DISK_GET_DRIVE_GEOMETRY_EX,  # ioctl api
+            b"",  # in buffer
+            32  # out buffer
+        ))
+
+    def tell(self):
+        # type: () -> int
+        """Get current (spoofed) position."""
+        return self.position
+
+    def _tell(self):
+        # type: () -> int
+        """Get current real position."""
+        if not self.handle:
+            self.handle = self.get_handle()
+        return win32file.SetFilePointer(self.handle, 0, win32file.FILE_CURRENT)
+
+    def seek(self, offset, whence=os.SEEK_SET):
+        # type: (int, int) -> int
+        """Seek at any point in the stream, in an aligned way."""
+        if whence == os.SEEK_CUR:
+            whence = self.tell()
+        elif whence == os.SEEK_END:
+            whence = len(self)
+
+        to = whence + offset
+        closest = self.align(to)  # get as close as we can while being aligned
+
+        if not self.handle:
+            self.handle = self.get_handle()
+
+        pos = win32file.SetFilePointer(self.handle, closest, win32file.FILE_BEGIN)
+        if pos != closest:
+            raise IOError(f"Seek was not precise...")
+
+        self.position = to  # not actually at this location, read will deal with it
+        return to
+
+    def read(self, size=-1):
+        # type: (int) -> Optional[bytes]
+        """Read any amount of bytes in the stream, in an aligned way."""
+        if not self.handle:
+            self.handle = self.get_handle()
+
+        sector_size = self.geometry[-3]
+        offset = abs(self._tell() - self.tell())
+
+        has_data = b''
+        while self._tell() < self.tell() + size:
+            res, data = win32file.ReadFile(self.handle, sector_size, None)
+            if res != 0:
+                raise IOError(f"An error occurred: {res} {data}")
+            if len(data) < sector_size:
+                raise IOError(f"Read {sector_size - len(data)} less bytes than requested...")
+            has_data += data
+        # seek to the position wanted + size read, which will then be re-aligned
+        self.seek(self.tell() + size)
+
+        return has_data[offset:offset + size]
+
+    def align(self, size, to=None):
+        # type: (int, Optional[int]) -> int
+        """
+        Align size to the closest but floor mod `to` value.
+        Examples:
+            align(513, to=512)
+            >>>512
+            align(1023, to=512)
+            >>>512
+            align(1026, to=512)
+            >>>1024
+            align(12, to=10)
+            >>>10
+        """
+        if not to:
+            to = self.geometry[-3]  # logical bytes per sector value
+        return math.floor(size / to) * to


### PR DESCRIPTION
Fixes #50 and Closes #60. Any other issue I have open can be considered an issue unrelated, aka just another bug discovered through the fight to get Windows to work with block devices.

This creates a *new* wrapper class that instead of using WMI, uses pywin32 directly and gets the size through [IOCTL_DISK_GET_DRIVE_GEOMETRY_EX](https://docs.microsoft.com/en-us/windows/win32/api/winioctl/ns-winioctl-disk_geometry_ex). It's also an optimized class of my two previous WindowsRawDevice classes.

IOCTL_DISK_GET_DRIVE_GEOMETRY_EX actually returns the FULL actual disc size compared to how it was done in #60 with WMI.
Not only that but this fixes the issues with being unable to read the full size of the disc (specifically the last 5*2048 sectors) as I unlocked the access using [FSCTL_ALLOW_EXTENDED_DASD_IO](https://docs.microsoft.com/en-us/windows/win32/api/winioctl/ni-winioctl-fsctl_allow_extended_dasd_io).

There's also a noticeable speed improvement compared to #60.

Do note, however, since this does use pywin32, that adds another dependency to the project. Perhaps it could be added as an extra/optional dependency, or specify in requirements.txt/setuptools that it's required for Windows. It also seems to only support 3.6+ (which is fair, anything older is EOL).