### PR TITLE
isohdpfx.bin thinks sectors are 512 bytes, not 2048 bytes

### DIFF
--- a/pycdlib/isohybrid.py
+++ b/pycdlib/isohybrid.py
@@ -945,7 +945,7 @@ class IsoHybrid(object):
         if not self._initialized:
             raise pycdlibexception.PyCdlibInternalError('This IsoHybrid object is not initialized')
 
-        self.rba = current_extent
+        self.rba = current_extent * 4 # Plain old ISOLINUX expects LBA * 4 too, apparently
 
     def update_efi(self, current_extent, sector_count, iso_size):
         # type: (int, int, int) -> None


### PR DESCRIPTION
The MBR boot code ISOLINUX uses to implement isohybrid mode needs to
know where to find ISOLINUX, but expects that to be expressed in
512-byte blocks.

See https://github.com/clalancette/pycdlib/issues/68