### PR TITLE
Fix Win32 Raw Devices with a size greater than 4GB~

### DIFF
--- a/pycdlib/utils.py
+++ b/pycdlib/utils.py
@@ -518,14 +518,16 @@ class Win32RawDevice:
             Sectors Per Track
             Bytes Per Sector
             Disk Size
-            Extra Data
         """
-        return struct.unpack("8L", win32file.DeviceIoControl(  # type: ignore
+        geometry_ex = win32file.DeviceIoControl(  # type: ignore
             self.handle,  # handle
             winioctlcon.IOCTL_DISK_GET_DRIVE_GEOMETRY_EX,  # type: ignore
-            b"",  # in buffer
+            None,  # in buffer
             32  # out buffer
-        ))
+        )
+        geometry = struct.unpack("6L", geometry_ex[:24])
+        disk_size = struct.unpack("<Q", geometry_ex[24:])[0]
+        return (*geometry, disk_size)
 
     def tell(self):
         # type: () -> int

--- a/pycdlib/utils.py
+++ b/pycdlib/utils.py
@@ -469,7 +469,7 @@ class Win32RawDevice:
 
     def __len__(self):
         # type: () -> int
-        return self.geometry[-2]
+        return self.geometry[-1]
 
     def dispose(self):
         # type: () -> None
@@ -568,7 +568,7 @@ class Win32RawDevice:
         if not self.handle:
             self.handle = self.get_handle()
 
-        sector_size = self.geometry[-3]
+        sector_size = self.geometry[-2]
         offset = abs(self._tell() - self.tell())
 
         has_data = b''
@@ -599,5 +599,5 @@ class Win32RawDevice:
             >>>10
         """
         if to is None:
-            to = self.geometry[-3]  # logical bytes per sector value
+            to = self.geometry[-2]  # logical bytes per sector value
         return math.floor(size / to) * to


### PR DESCRIPTION
The struct unpacked only 4 bytes (unsigned long) worth of data for the Disk Size, and left the "Extra Data" as-is, unused. It seems this "Extra Data" is essentially an extension to the data size for 64-bit systems.

You can just use the 4 bytes only, if it's for a device or ISO roughly 4GB~ or less, but if it's more, it would need to unpack all 8 bytes after the DISK_GEOMETRY.

It is also important for it to be `<` and not the default `@` (which nowadays may be `>`).

Without this change, any device that's 5gb~ or more (give or take) will not have the correct total disk size, therefore all SEEK_END or len() calls will fail.