### PR TITLE
doc examples - add python code highlighting

### DIFF
--- a/docs/example-creating-bootable-iso.md
+++ b/docs/example-creating-bootable-iso.md
@@ -1,7 +1,7 @@
 # Example: Creating a bootable ISO (El Torito)
 This example will show how to create a bootable [El Torito](standards.md#el-torito) ISO.  Here's the complete code for the example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -25,7 +25,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -36,7 +36,7 @@ import pycdlib
 
 As usual, import the necessary libraries, including pycdlib.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 
 iso.new()
@@ -44,20 +44,20 @@ iso.new()
 
 Create a new PyCdlib object, and then create a new, basic ISO.
 
-```
+```python
 bootstr = b'boot\n'
 iso.add_fp(BytesIO(bootstr), len(bootstr), '/BOOT.;1')
 ```
 
 Add a file called /BOOT.;1 to the ISO.  This is the file that contains the data to be used to boot the ISO when placed into a computer.  The name of the file can be anything (and can even be nested in directories), but the contents have to be very specific.  Getting the appropriate data into the boot file is beyond the scope of this tutorial; see [isolinux](http://www.syslinux.org/wiki/index.php?title=ISOLINUX) for one way of getting the appropriate data.  Suffice it to say that the example code that we are using above will not actually boot, but is good enough to show the PyCdlib API usage.
 
-```
+```python
 iso.add_eltorito('/BOOT.;1')
 ```
 
 Add El Torito to the ISO, making the boot file "/BOOT.;1".  After this call, the ISO is actually bootable.  By default, the [add_eltorito](pycdlib-api.html#PyCdlib-add_eltorito) method will use so-called "no emulation" booting, which allows arbitrary data in the boot file.  "Hard drive" and "floppy" emulation is also supported, though these options are more esoteric and need specifically configured boot data to work properly.
 
-```
+```python
 iso.write('eltorito.iso')
 
 iso.close()

--- a/docs/example-creating-hybrid-bootable-iso.md
+++ b/docs/example-creating-hybrid-bootable-iso.md
@@ -3,7 +3,7 @@ The first 32768 bytes of any ISO are designated as "system use".  In a normal IS
 
 Here's the complete code for the example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -29,7 +29,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -40,7 +40,7 @@ import pycdlib
 
 As usual, import the necessary libraries, including pycdlib.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 
 iso.new()
@@ -48,26 +48,26 @@ iso.new()
 
 Create a new PyCdlib object, and then create a new, basic ISO.
 
-```
+```python
 isolinuxstr = b'\x00'*0x40 + b'\xfb\xc0\x78\x70'
 iso.add_fp(BytesIO(isolinuxstr), len(isolinuxstr), '/BOOT.;1')
 ```
 
 Add a file called /BOOT.;1 to the ISO.  The contents of this conform to the expected boot start sequence as specified by isolinux.  A complete discussion of the correct form of the file is out of scope for this tutorial; see [isolinux](http://www.syslinux.org/wiki/index.php?title=ISOLINUX) for more details.  The above is the minimum code that conforms to the sequence, though it is not technically bootable.
 
-```
+```python
 iso.add_eltorito('/BOOT.;1', boot_load_size=4)
 ```
 
 Add El Torito to the ISO, making the boot file "/BOOT.;1", and setting the `boot_load_size` to 4.  The `boot_load_size` is the number of 512-bytes sectors to read during initial boot.  While other values may be allowed for this, all current examples (from cdrkit or isolinux) use this value.  After this call, the ISO is El Torito bootable, but not yet a hybrid ISO.
 
-```
+```python
 iso.add_isohybrid()
 ```
 
 Add the boot file to the system use area, making this a hybrid ISO.  There are various parameters that can be passed to control how the hybrid file is added, but the defaults are typically good enough for creating a hybrid ISO similar to those made for most Linux distributions.
 
-```
+```python
 iso.write('eltorito.iso')
 
 iso.close()

--- a/docs/example-creating-joliet-iso.md
+++ b/docs/example-creating-joliet-iso.md
@@ -1,7 +1,7 @@
 # Example: Creating an ISO with Joliet extensions
 This example will show how to create an ISO with the [Joliet](standards.md#joliet) extensions.  Here's the complete code for the example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -20,7 +20,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -31,27 +31,27 @@ import pycdlib
 
 As in earlier examples, import the relevant libraries, including pycdlib itself.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.new(joliet=3)
 ```
 
 Create a new PyCdlib object, and then create a new ISO with that object.  In order to make it have Joliet extensions, we pass the argument `joliet=3` to the [new](pycdlib-api.html#PyCdlib-new) method.  PyCdlib supports Joliet levels 1, 2, and 3, but level 3 is by far the most common, so is recommended.
 
-```
+```python
 foostr = b'foo\n'
 iso.add_fp(BytesIO(foostr), len(foostr), '/FOO.;1', joliet_path='/foo')
 ```
 
 As in earlier examples, create a new file on the ISO from a string.  Because this is a Joliet ISO, we have to provide the `joliet_path` argument to [add_fp](pycdlib-api.html#PyCdlib-add_fp) as well.  In contrast to Rock Ridge, Joliet is a completely different context from the original ISO9660 structure, and so the argument to be passed here must be an absolute path, not a name.  Because of this, the Joliet file can be on a completely different part of the directory structure, or be omitted completely (in which case the file will only show up on the ISO9660 portion of the ISO).  In practice the Joliet portion of the ISO almost always mirrors the ISO9660 portion of the ISO, so it is recommended to do that when creating new Joliet ISOs.
 
-```
+```python
 iso.add_directory('/DIR1', joliet_path='/dir1')
 ```
 
 Create a new directory on the ISO.  Again we must pass the `joliet_path` argument to [add_directory](pycdlib-api.html#PyCdlib-add_directory), for all of the same reasons and with the same restrictions as we saw above for [add_fp](pycdlib-api.html#PyCdlib-add_fp).
 
-```
+```python
 iso.write('new.iso')
 iso.close()
 ```

--- a/docs/example-creating-new-basic-iso.md
+++ b/docs/example-creating-new-basic-iso.md
@@ -1,7 +1,7 @@
 # Example: Creating a new, basic ISO
 This example will show how to create a new, basic ISO with no extensions.  Here's the complete code for this example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -23,7 +23,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -34,38 +34,38 @@ import pycdlib
 
 First import the relevant libraries, including pycdlib itself.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 ```
 
 Create a new PyCdlib object.  At this point, the object can only do one of two things: open up an existing ISO, or create a new ISO.
 
-```
+```python
 iso.new()
 ```
 
 Create a new ISO using the [new](pycdlib-api.html#PyCdlib-new) method.  The [new](pycdlib-api.html#PyCdlib-new) method has quite a few available arguments, but by passing no arguments, we ask for a basic interchange level 1 ISO with no extensions.  At this point, we could write out a valid ISO image, but it won't have any files or directories in it, so it wouldn't be very interesting.
 
-```
+```python
 foostr = b'foo\n'
 iso.add_fp(BytesIO(foostr), len(foostr), '/FOO.;1')
 ```
 
 Now we add a new file to the ISO.  There are a few details to notice in this code.  The first detail is that there are two related APIs called [add_file](pycdlib-api.html#PyCdlib-add_file) and [add_fp](pycdlib-api.html#PyCdlib-add_fp).  The [add_file](pycdlib-api.html#PyCdlib-add_file) API takes the pathname to a file on the local disk to get the contents from.  The [add_fp](pycdlib-api.html#PyCdlib-add_fp) API takes a file-like object to get the contents from; this can be a normal file-object (such as that returned by standard python [open](https://docs.python.org/3.6/library/functions.html#open)), or this can be any other object that acts like a file.  In this case, we use a python [BytesIO](https://docs.python.org/3/library/io.html#binary-i-o) object, which behaves like a file-object but is backed by a string.  The second detail to notice is that the second argument to [add_fp](pycdlib-api.html#PyCdlib-add_fp) is the length of the content to add to the ISO.  Since file-like objects don't have a standard way to get the length, this must be provided by the user.  The [add_file](pycdlib-api.html#PyCdlib-add_file) API can use the length of the file itself for this purpose, so the second argument isn't required there.  The third detail to notice is that the final argument to [add_fp](pycdlib-api.html#PyCdlib-add_fp) is the location of the file on the resulting ISO (also known as the `iso_path`).  The `iso_path` is specified using something similar to a Unix file path.  These paths differ from Unix file paths in that they *must* be absolute paths, since PyCdlib has no concept of a current working directory.  All intermediate directories along the path must exist, otherwise the [add_fp](pycdlib-api.html#PyCdlib-add_fp) call will fail (the `/` root directory always exists and doesn't have to be explicitly created).  Also note that ISO9660-compliant filenames have a slightly odd format owing to their history.  In standard ISO interchange level 1, filenames have a maximum of 8 characters, followed by a required dot, followed by a maximum 3 character extension, followed by a semicolon and a version.  The filename and the extension are both optional, but one or the other must exist.  Only uppercase letters, numbers, and underscore are allowed for either the name or extension.  If any of these rules are violated, PyCdlib will throw an exception.
 
-```
+```python
 iso.add_directory('/DIR1')
 ```
 
 Here we add a new directory to the ISO called `DIR1`.  Like [add_fp](pycdlib-api.html#PyCdlib-add_fp), the `iso_path` argument to [add_directory](pycdlib-api.html#PyCdlib-add_directory) is an absolute, Unix like pathname.  The rules for ISO directory names are similar to that of filenames, except that directory names do not have extensions and do not have versions.
 
-```
+```python
 iso.write('new.iso')
 ```
 
 Now we finally get to write out the ISO we just created.  The process of writing out an ISO is sometimes called "mastering".  In any case, this is the process of writing the contents of the ISO out to a file on disk.  Similar to the [add_file](pycdlib-api.html#PyCdlib-add_file) and [add_fp](pycdlib-api.html#PyCdlib-add_fp) methods, there are the related [write](pycdlib-api.html#PyCdlib-write) and [write_fp](pycdlib-api.html#PyCdlib-write_fp) methods, the former of which takes a filename to write to, and the latter of which takes a file-like object.
 
-```
+```python
 iso.close()
 ```
 

--- a/docs/example-creating-rock-ridge-iso.md
+++ b/docs/example-creating-rock-ridge-iso.md
@@ -1,7 +1,7 @@
 # Example: Creating an ISO with Rock Ridge extensions
 This example will show how to create an ISO with the [Rock Ridge](standards.md#rock-ridge) extensions.  Here's the complete code for the example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -20,7 +20,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -31,27 +31,27 @@ import pycdlib
 
 As in earlier examples, import the relevant libraries, including pycdlib itself.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.new(rock_ridge='1.09')
 ```
 
 Create a new PyCdlib object, and then create a new ISO with that object.  In order to make it have Rock Ridge extensions, we pass the argument `rock_ridge="1.09"` to the [new](pycdlib-api.html#PyCdlib-new) method.  PyCdlib supports Rock Ridge versions 1.09, 1.10, and 1.12, though 1.09 is more common.
 
-```
+```python
 foostr = b'foo\n'
 iso.add_fp(BytesIO(foostr), len(foostr), '/FOO.;1', rr_name='foo')
 ```
 
 As in earlier examples, create a new file on the ISO from a string.  Because this is a Rock Ridge ISO, we have to also supply the `rr_name` argument to the [add_fp](pycdlib-api.html#PyCdlib-add_fp) method.  Forgetting the `rr_name` argument on a Rock Ridge ISO is an error and PyCdlib will throw an exception.  Note that it is called `rr_name`, and that the argument given is truly a name, not an absolute path.  This is because Rock Ridge is an extension to the original ISO9660, and this alternate name will be stored alongside the original ISO data.
 
-```
+```python
 iso.add_directory('/DIR1', rr_name='dir1')
 ```
 
 Create a new directory on the ISO.  Again we must pass the `rr_name` argument to [add_directory](pycdlib-api.html#PyCdlib-add_directory), for all of the same reasons and with the same restrictions as we saw above for [add_fp](pycdlib-api.html#PyCdlib-add_fp).
 
-```
+```python
 iso.write('new.iso')
 iso.close()
 ```

--- a/docs/example-creating-udf-iso.md
+++ b/docs/example-creating-udf-iso.md
@@ -1,7 +1,7 @@
 # Example: Creating an ISO with UDF
 This example will show how to create an ISO with the [UDF](standards.md#udf) bridge format.  Here's the complete code for the example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -20,7 +20,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -31,27 +31,27 @@ import pycdlib
 
 As in earlier examples, import the relevant libraries, including pycdlib itself.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.new(udf=True)
 ```
 
 Create a new PyCdlib object, and then create a new ISO with that object.  In order to make it have UDF, we pass the argument `udf=True` to the [new](pycdlib-api.html#PyCdlib-new) method.
 
-```
+```python
 foostr = b'foo\n'
 iso.add_fp(BytesIO(foostr), len(foostr), '/FOO.;1', udf_path='/foo')
 ```
 
 As in earlier examples, create a new file on the ISO from a string.  Because this is a UDF ISO, we have to provide the `udf_path` argument to [add_fp](pycdlib-api.html#PyCdlib-add_fp) as well.  Like Joliet, UDF is a completely different context from the original ISO9660 structure, and so the argument to be passed here must be an absolute path, not a name.  Because of this, the UDF file can be on a completely different part of the directory structure, or be omitted completely (in which case the file will only show up on the ISO9660 portion of the ISO).
 
-```
+```python
 iso.add_directory('/DIR1', udf_path='/dir1')
 ```
 
 Create a new directory on the ISO.  Again we must pass the `udf_path` argument to [add_directory](pycdlib-api.html#PyCdlib-add_directory), for all of the same reasons and with the same restrictions as we saw above for [add_fp](pycdlib-api.html#PyCdlib-add_fp).
 
-```
+```python
 iso.write('new.iso')
 iso.close()
 ```

--- a/docs/example-extracting-data-from-iso.md
+++ b/docs/example-extracting-data-from-iso.md
@@ -1,7 +1,7 @@
 # Example: Extracting data from an existing ISO
 This example will show how to extract data from an existing ISO.  Here's the complete code for this example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -27,7 +27,7 @@ print(extracted.getvalue().decode('utf-8'))
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -38,7 +38,7 @@ import pycdlib
 
 As we've seen before, import pycdlib.  We also import the [BytesIO](https://docs.python.org/3/library/io.html#binary-i-o) module so we can use a python string as a file-like object.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.new()
 foostr = b'foo\n'
@@ -50,20 +50,20 @@ iso.close()
 
 This code creates a new ISO, adds a single file to it, and writes it out.  This is very similar to the code in [Creating a new, basic ISO](example-creating-new-basic-iso.md), so see that example for more information.  One important difference in this code is that it uses a `BytesIO` object to master the ISO into so we don't have to write any temporary data out to the filesystem; it all happens in memory.
 
-```
+```python
 iso.open_fp(out)
 ```
 
 Here we open up the ISO we created above.  We can safely re-use the PyCdlib object because we called the [close](pycdlib-apihtml#PyCdlib-close) method earlier.  Also note that we use [open_fp](pycdlib-api.html#PyCdlib-open_fp) to open the file-like object we wrote into using [write_fp](pycdlib-api.html#PyCdlib-write_fp) above.
 
-```
+```python
 extracted = BytesIO()
 iso.get_file_from_iso_fp(extracted, iso_path='/FOO.;1')
 ```
 
 Now we use the [get_file_from_iso_fp](pycdlib-api.html#PyCdlib-get_file_from_iso_fp) API to extract the data from a file on the ISO.  In this case, we access the "/FOO.;1" file that we created above, and write out the data to the BytesIO object `extracted`.
 
-```
+```python
 iso.close()
 
 print(extracted)

--- a/docs/example-forcing-consistency.md
+++ b/docs/example-forcing-consistency.md
@@ -8,7 +8,7 @@ Of the two, using lazy metadata updating and only calling [force_consistency](py
 
 Here's the complete code for the example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -32,7 +32,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -43,39 +43,39 @@ import pycdlib
 
 As in earlier examples, import the relevant libraries, including pycdlib itself.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.new()
 ```
 
 As in earlier examples, create a new PyCdlib object and then create a new ISO with no extensions.
 
-```
+```python
 foostr = b'foo\n'
 iso.add_fp(BytesIO(foostr), len(foostr), '/FOO.;1')
 ```
 
 As in earlier examples, add a new file to the ISO.
 
-```
+```python
 iso.force_consistency()
 ```
 
 Now force consistency on the ISO.  This will cause PyCdlib to update all of the metadata on the ISO, and after this call all of the metadata for all entries on the ISO will be accurate.
 
-```
+```python
 iso.add_directory('/DIR1')
 ```
 
 As in earlier examples, add a new directory to the ISO.  Note that the metadata on the ISO is now out-of-date again, so to accurately look at the metadata, [force_consistency](pycdlib-api.html#PyCdlib-force_consistency) would have to be called again after this modification.
 
-```
+```python
 iso.write('new.iso')
 ```
 
 As in earlier examples, write the ISO out to a file.  The [write](pycdlib-api.html#PyCdlib-write) method implicitly does a metadata update since it needs all of the metadata to be accurate to successfully write out the ISO.
 
-```
+```python
 iso.close()
 ```
 

--- a/docs/example-managing-hard-links.md
+++ b/docs/example-managing-hard-links.md
@@ -12,7 +12,7 @@ The data can be referred to zero, one, or many times from each of these contexts
 
 An example should help to illustrate the concept.  Here's the complete code for the example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -38,7 +38,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -49,40 +49,40 @@ import pycdlib
 
 As in earlier examples, import the relevant libraries, including pycdlib itself.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.new(joliet=3)
 ```
 
 As in earlier examples, create a PyCdlib object, and then create a new, empty ISO with the Joliet extensions.
 
-```
+```python
 foostr = b'foo\n'
 iso.add_fp(BytesIO(foostr), len(foostr), '/FOO.;1', joliet_path='/foo')
 ```
 
 As in earlier examples, add a new file to the ISO.  Here we have provided both the ISO path '/FOO.;1' and the Joliet path '/foo', so the file implicitly has two links; one from the ISO context, and one from the Joliet context.
 
-```
+```python
 iso.add_hard_link(iso_old_path='/FOO.;1', iso_new_path='/BAR.;1')
 ```
 
 Add a hard-link from the original '/FOO.;1' location in the ISO context to a second location in the ISO context '/BAR.;1'.  This takes up no additional space on the ISO for the data, only for the metadata.
 
-```
+```python
 iso.rm_hard_link(joliet_path='/foo')
 ```
 
 Remove the link from the Joliet context for the file.  Now this file is effectively hidden from the Joliet context, while still being visible in the ISO context.
 
-```
+```python
 outiso = BytesIO()
 iso.write_fp(outiso)
 ```
 
 As in earlier examples, write the ISO out to the BytesIO object.
 
-```
+```python
 iso.close()
 ```
 

--- a/docs/example-modifying-file-in-place.md
+++ b/docs/example-modifying-file-in-place.md
@@ -9,7 +9,7 @@ Despite these limitations, modifying a file in place is extremely fast, much fas
 
 Here's the complete code for the example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -37,7 +37,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -48,7 +48,7 @@ import pycdlib
 
 As in earlier examples, import the relevant libraries, including pycdlib itself.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.new()
 foostr = b'foo\n'
@@ -60,20 +60,20 @@ iso.close()
 
 Create an ISO with a single file called "/FOO.;1" on it.  This is similar to previous examples, with the one exception that we are using the [write_fp](pycdlib-api.html#PyCdlib-write_fp) API to write the ISO out to a string in memory (rather than on-disk).  Note that at this point, the "/FOO.;1" file has the contents 'foo\n' on the ISO.
 
-```
+```python
 iso.open_fp(outiso)
 ```
 
 Open up the ISO that is in the `outiso` BytesIO object.
 
-```
+```python
 bazstr = b'bazzzzzz\n'
 iso.modify_file_in_place(BytesIO(bazstr), len(bazstr), '/FOO.;1')
 ```
 
 Here we get to the heart of the example.  We use [modify_file_in_place](pycdlib-api.html#PyCdlib-modify_file_in_place) to modify the "/FOO.;1" file to have the contents 'bazzzzzz\n'.  We are allowed to expand the size of the file because we are still smaller than the size of the extent (the [modify_file_in_place](pycdlib-api.html#PyCdlib-modify_file_in_place) API enforces this).
 
-```
+```python
 modifiediso = BytesIO()
 iso.write_fp(modifiediso)
 iso.close()

--- a/docs/example-opening-existing-iso.md
+++ b/docs/example-opening-existing-iso.md
@@ -1,7 +1,7 @@
 # Example: Opening an existing ISO
 This example will show how to examine an existing ISO.  Here's the complete code for this example:
 
-```
+```python
 import sys
 import pycdlib
 
@@ -16,28 +16,28 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 import sys
 import pycdlib
 ```
 
 As we've seen before, import pycdlib.  We also import the sys module so we get access to the command-line arguments.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.open(sys.argv[1])
 ```
 
 As we saw in the last example, create a new PyCdlib object.  Once we have the object, we can then open up the file passed on the command-line.  During the open, PyCdlib will parse all of the metadata on the ISO, so if the file is coming over a network, this may take a bit of time.  Note that besides the [open](pycdlib-api.html#PyCdlib-open) method, there is also an [open_fp](pycdlib-api.html#PyCdlib-open_fp) method that takes an arbitrary file-like object.
 
-```
+```python
 for child in iso.list_children(iso_path='/'):
     print(child.file_identifier())
 ```
 
 Use the [list_children](pycdlib-api.html#PyCdlib-list_children) API from PyCdlib to iterate over all of the files and directories at the root of the ISO.  As discussed in the [Creating a new, basic ISO](example-creating-new-basic-iso.md) example, the paths are Unix-like absolute paths.
 
-```
+```python
 iso.close()
 ```
 

--- a/docs/example-reading-file-in-chunks.md
+++ b/docs/example-reading-file-in-chunks.md
@@ -1,7 +1,7 @@
 # Example: Reading a large file in chunks
 It may be useful in some applications to be able to read a file from an ISO a bit at a time and do some processing on it.  PyCdlib provides the context manager [open_file_from_iso](pycdlib-api.html#PyCdlib-open_file_from_iso) API to allow opening a file and reading in parts of it.  Here's the complete code for this example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -25,7 +25,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -36,7 +36,7 @@ import pycdlib
 
 As we've seen before, import pycdlib.  We also import the [BytesIO](https://docs.python.org/3/library/io.html#binary-i-o) module so we can use a python string as a file-like object.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.new()
 foostr = b'foofoo\n'
@@ -45,37 +45,37 @@ iso.add_fp(BytesIO(foostr), len(foostr), '/FOO.;1')
 
 This code creates a new ISO, adds a single file to it, and writes it out.  This is very similar to the code in [Creating a new, basic ISO](example-creating-new-basic-iso.md), so see that example for more information.
 
-```
+```python
 with iso.open_file_from_iso(iso_path='/FOO.;1') as infp:
 ```
 
 Here we use the [open_file_from_iso](pycdlib-api.html#PyCdlib-open_file_from_iso) API to get a context manager to the file that we created; this will be used in the rest of the explanations below.
 
-```
+```python
     all = infp.read()
 ```
 
 The first `read` call reads in all of the data in the file, so at the end of the call the "all" variable will contain `foofoo\n`. 
 
-```
+```python
     infp.seek(0)
 ```
 
 The 'seek' call then resets the file pointer back to the beginning of the file.
 
-```
+```python
     first = infp.read(3)
 ```
 
 If the `read` API is passed a number, it will read and return that many bytes.  In this case, the 'first' variable will end up containing `foo`.
 
-```
+```python
     second = infp.read()
 ```
 
 And now we read the rest of the data, so the 'second' variable will end up containing `foo\n`.
 
-```
+```python
 iso.close()
 ```
 

--- a/docs/example-using-facade.md
+++ b/docs/example-using-facade.md
@@ -1,7 +1,7 @@
 # Example: Using a facade
 This example will show how to access various aspects of an ISO with a [facade](examples.md#facades).  Here's the complete code for the example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -26,7 +26,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -37,33 +37,33 @@ import pycdlib
 
 As in earlier examples, import the relevant libraries, including pycdlib itself.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.new(joliet=3)
 ```
 
 Create a new PyCdlib object, and then create a new ISO with that object.  As in previous examples, make it a Joliet ISO by passing `joliet=3` to the [new](pycdlib-api.html#PyCdlib-new) method.
 
-```
+```python
 joliet = iso.get_joliet_facade()
 ```
 
 Fetch a Joliet facade for the PyCdlib object.  We'll use this for manipulation of the object below.
 
-```
+```python
 foostr = b'foo\n'
 joliet.add_fp(BytesIO(foostr), len(foostr), joliet_path='/foo')
 ```
 
 As in earlier examples, create a new file on the ISO from a string.  Note that we call the `add_fp` method on the facade, and that we *only* pass the joliet_path to the facade.  This simplifies things considerably for us.  However, this also means that the file will only show up in the Joliet context.  If we want it to show up in other contexts (like Rock Ridge or UDF), we have two options.  We can either use the more complicated form of the `add_fp` method on the original `PyCdlib` object, or we can call `add_hard_link` on the original `PyCdlib` object to make the file appear in other contexts.
 
-```
+```python
 joliet.add_directory(joliet_path='/dir1')
 ```
 
 Create a new directory on the ISO.  Again we use the facade to create the directory, so we only have to pass the `joliet_path`.
 
-```
+```python
 iso.write('new.iso')
 iso.close()
 ```

--- a/docs/example-walking-iso-filesystem.md
+++ b/docs/example-walking-iso-filesystem.md
@@ -1,7 +1,7 @@
 # Example: Walking the ISO filesystem
 In some circumstances it may be useful to walk all or some of the filesystem tree on the ISO.  For that purpose, PyCdlib provides the [walk](pycdlib-api.html#PyCdlib-walk) API.  Much like the built-in Python [os.walk](https://docs.python.org/3.6/library/os.html#os.walk) API, this method takes a PyCdlib full path, and iterates over the entire filesystem starting at that root.  For each directory, the method returns a 3-tuple of `(dirpath, dirnames, filenames)` that can be used by the user.  Here's the complete code for this example:
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -32,7 +32,7 @@ iso.close()
 
 Let's take a closer look at the code.
 
-```
+```python
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -43,14 +43,14 @@ import pycdlib
 
 As in earlier examples, import the relevant libraries, including pycdlib itself.
 
-```
+```python
 iso = pycdlib.PyCdlib()
 iso.new()
 ```
 
 Create a new PyCdlib object, and then create a new ISO with that object.
 
-```
+```python
 iso.add_directory('/DIR1')
 foostr = b'foo\n'
 iso.add_fp(BytesIO(foostr), len(foostr), '/DIR1/FOO.;1')
@@ -63,14 +63,14 @@ iso.add_fp(BytesIO(bazstr), len(bazstr), '/DIR2/BAZ.;1')
 
 As in earlier examples, create some new directories and files on the ISO from strings.
 
-```
+```python
 for dirname, dirlist, filelist in iso.walk(iso_path='/'):
     print("Dirname:", dirname, ", Dirlist:", dirlist, ", Filelist:", filelist)
 ```
 
 Use the [walk](pycdlib-api.html#PyCdlib-walk) API to iterate over the directories and files on the ISO, printing them out in turn.  Note that [walk](pycdlib-api.html#PyCdlib-walk) takes one and only one of `iso_path`, `rr_path`, `joliet_path`, or `udf_path`, and only accepts `rr_path`, `joliet_path`, or `udf_path` if the ISO supports those extensions.  Since we added a number of files and directories on the ISO, the above code will print out:
 
-```
+```python
 Dirname: / , Dirlist: ['DIR2', 'DIR1'] , Filelist: []
 Dirname: /DIR1 , Dirlist: [] , Filelist: ['FOO.;1', 'BAR.;1']
 Dirname: /DIR2 , Dirlist: [] , Filelist: ['BAZ.;1']
@@ -78,20 +78,20 @@ Dirname: /DIR2 , Dirlist: [] , Filelist: ['BAZ.;1']
 
 This can be interpreted as follows.  The "dirname" is the name of the directory currently being examined; for the root it is `/`, while it is `/DIR1` and `/DIR2` for the respective directories.  The "dirlist" is the list of sub-directores at this level of the hierarchy; the root contains `DIR1` and `DIR2`, while each sub-directory has no sub-sub-directories and hence has an empty list.  The "filelist" is the list of files at this level of the hierarchy; the root contains no files so has an empty list, while `DIR1` contains `FOO.;1` and `BAR.;1` and `DIR2` contains `BAZ.;1`.
 
-```
+```python
 for dirname, dirlist, filelist in iso.walk(iso_path='/DIR1'):
     print("Dirname:", dirname, ", Dirlist:", dirlist, ", Filelist:", filelist)
 ```
 
 The second call to [walk](pycdlib-api.html#PyCdlib-walk) starts in the `DIR1` subdirectory, so the output from this loop looks like:
 
-```
+```sh
 Dirname: /DIR1 , Dirlist: [] , Filelist: ['FOO.;1', 'BAR.;1']
 ```
 
 Like we saw before, the "dirname" for this level is `/DIR1`, while the "dirlist" is empty since there are no subdirectories, and the filelist contains `FOO.;1` and `BAR.;1`.
 
-```
+```python
 iso.close()
 ```
 


### PR DESCRIPTION
adds python highlighting to the python code examples in the docs

