### PR TITLE
fix: large file bugfix in udf image

### DIFF
--- a/pycdlib/udf.py
+++ b/pycdlib/udf.py
@@ -4179,7 +4179,7 @@ class UDFFileEntry(object):
         current_assignment = start_extent
         for desc in self.alloc_descs:
             desc.log_block_num = current_assignment
-            current_assignment += 1
+            current_assignment += utils.ceiling_div(desc.extent_length, 2048)
 
     def get_data_length(self):
         # type: () -> int


### PR DESCRIPTION
In the UDF image, modify the assignment of the LOG_BLOCK_NUM of the AD for a file with a size of 0x3ffff800 or more in the UDF image.
issue #74 