### PR TITLE
re-export PyCdlib using a redundant symbol alias to make it a public export

### DIFF
--- a/pycdlib/__init__.py
+++ b/pycdlib/__init__.py
@@ -2,4 +2,4 @@
 Pycdlib is a pure python library to parse, write (master), and create ISO9660
 files.  These files are suitable for writing to a CD or USB.
 """
-from .pycdlib import PyCdlib  # NOQA
+from .pycdlib import PyCdlib as PyCdlib # NOQA


### PR DESCRIPTION
As the project is now being marked as `py.typed` since commit 9f00509c9abfeb37d619c37c78b1c14bb47f56a6, the `PyCdlib` import in `pycdlib/__init__.py` is considered as a private import. To allow other code to import and use such symbol without typing errors, an explicit re-export is needed as described in https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#library-interface. This pull request simply re-exports that symbol to allow importing it without typing errors.