### PR TITLE
When writing isos files and directories had the wrong timestamps (month was used for the day value)

### DIFF
--- a/pycdlib/udf.py
+++ b/pycdlib/udf.py
@@ -1115,7 +1115,7 @@ class UDFTimestamp(object):
         self.timetype = 1
         self.year = local.tm_year
         self.month = local.tm_mon
-        self.day = local.tm_mon
+        self.day = local.tm_mday
         self.hour = local.tm_hour
         self.minute = local.tm_min
         self.second = local.tm_sec


### PR DESCRIPTION
When creating a UDFTimestamp object, tm_month was copied into both the month and the day field.
This resulted in bogus timestamps in the final iso.