### PR TITLE
Fix incorrect ISO metadata being written after shrinking

### DIFF
--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -1661,6 +1661,17 @@ class PyCdlib:
             self.udf_anchors[-1].set_extent_location(current_extent,
                                                      self.udf_main_descs.pvds[0].extent_location(),
                                                      self.udf_reserve_descs.pvds[0].extent_location())
+            # Update space_size so the second anchor is at the last extent.
+            # Without this, ISOs with a more compact reshuffled layout than
+            # the original would place the anchor at a position the parser
+            # doesn't check, breaking round-trip open/write/open.
+            new_space_size = current_extent + 1
+            for pvd in self.pvds:
+                pvd.space_size = new_space_size
+            if self.joliet_vd is not None:
+                self.joliet_vd.space_size = new_space_size
+            if self.enhanced_vd is not None:
+                self.enhanced_vd.space_size = new_space_size
 
         if current_extent > self.pvd.space_size:
             raise pycdlibexception.PyCdlibInternalError('Assigned an extent beyond the ISO (%d > %d)' % (current_extent, self.pvd.space_size))

--- a/tests/integration/test_common.py
+++ b/tests/integration/test_common.py
@@ -5762,6 +5762,45 @@ def check_isolevel4_deep_directory(iso, filesize):
 
     internal_check_file_contents(iso, path='/dir1/dir2/dir3/dir4/dir5/dir6/dir7/foo', contents=b'foo\n', which='iso_path')
 
+def check_udf_anchor_after_shrink(iso, filesize):
+    assert(filesize == 555008)
+
+    internal_check_pvd(iso.pvd, extent=16, size=271, ptbl_size=10, ptbl_location_le=263, ptbl_location_be=265)
+
+    internal_check_terminator(iso.vdsts, extent=17)
+
+    internal_check_ptr(iso.pvd.root_dir_record.ptr, name=b'\x00', len_di=1, loc=267, parent=1)
+
+    internal_check_root_dir_record(iso.pvd.root_dir_record, num_children=4, data_length=2048, extent_location=267, rr=False, rr_nlinks=0, xa=False, rr_onetwelve=False)
+
+    internal_check_file(iso.pvd.root_dir_record.children[2], name=b'BAR.;1', dr_len=40, loc=268, datalen=4, hidden=False, multi_extent=False)
+    internal_check_file_contents(iso, path='/BAR.;1', contents=b'bar\n', which='iso_path')
+
+    internal_check_file(iso.pvd.root_dir_record.children[3], name=b'FOO.;1', dr_len=40, loc=269, datalen=4, hidden=False, multi_extent=False)
+    internal_check_file_contents(iso, path='/FOO.;1', contents=b'foo\n', which='iso_path')
+
+    internal_check_udf_headers(iso, bea_extent=18, end_anchor_extent=270, part_length=14, unique_id=263, num_dirs=1, num_files=2)
+
+    internal_check_udf_file_entry(iso.udf_root, location=259, tag_location=2, num_links=1, info_len=128, num_blocks_recorded=1, num_fi_descs=3, file_type='dir', num_alloc_descs=1)
+
+    internal_check_udf_file_ident_desc(iso.udf_root.fi_descs[0], extent=260, tag_location=3, characteristics=10, blocknum=2, abs_blocknum=0, name=b'', isparent=True, isdir=True)
+
+    foo_file_ident = iso.udf_root.fi_descs[1]
+    internal_check_udf_file_ident_desc(foo_file_ident, extent=260, tag_location=3, characteristics=0, blocknum=4, abs_blocknum=261, name=b'foo', isparent=False, isdir=False)
+
+    foo_file_entry = foo_file_ident.file_entry
+    internal_check_udf_file_entry(foo_file_entry, location=261, tag_location=4, num_links=1, info_len=4, num_blocks_recorded=1, num_fi_descs=0, file_type='file', num_alloc_descs=1)
+
+    internal_check_file_contents(iso, path='/foo', contents=b'foo\n', which='udf_path')
+
+    bar_file_ident = iso.udf_root.fi_descs[2]
+    internal_check_udf_file_ident_desc(bar_file_ident, extent=260, tag_location=3, characteristics=0, blocknum=5, abs_blocknum=262, name=b'bar', isparent=False, isdir=False)
+
+    bar_file_entry = bar_file_ident.file_entry
+    internal_check_udf_file_entry(bar_file_entry, location=262, tag_location=5, num_links=1, info_len=4, num_blocks_recorded=1, num_fi_descs=0, file_type='file', num_alloc_descs=1)
+
+    internal_check_file_contents(iso, path='/bar', contents=b'bar\n', which='udf_path')
+
 def check_onefile_one_extent_path_tables(iso, filesize):
     assert(filesize == 47104)
 

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -6493,6 +6493,47 @@ def test_new_udf_eltorito_multi_boot_rm_file():
 
     iso.close()
 
+def test_new_udf_anchor_after_shrink():
+    # Create a UDF ISO with a small file and a large file, write it, reopen,
+    # remove the large file, add a different small file, write again, then
+    # reopen.  The removal makes the reshuffled layout more compact than the
+    # original pvd.space_size, which (before the fix) caused the second UDF
+    # anchor to be placed at an extent the parser wouldn't check.
+    iso = pycdlib.PyCdlib()
+    iso.new(udf='2.60')
+
+    foostr = b'foo\n'
+    iso.add_fp(io.BytesIO(foostr), len(foostr), '/FOO.;1', udf_path='/foo')
+
+    bigstr = b'x' * 102400
+    iso.add_fp(io.BytesIO(bigstr), len(bigstr), '/BIG.;1', udf_path='/big')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+
+    iso2.rm_file(iso_path='/BIG.;1', udf_path='/big')
+
+    barstr = b'bar\n'
+    iso2.add_fp(io.BytesIO(barstr), len(barstr), '/BAR.;1', udf_path='/bar')
+
+    out2 = io.BytesIO()
+    iso2.write_fp(out2)
+
+    check_udf_anchor_after_shrink(iso2, len(out2.getvalue()))
+
+    iso2.close()
+
+    # The critical check: reopen the twice-written ISO and verify it parses
+    # correctly, confirming both UDF anchors are at locations the parser finds.
+    iso3 = pycdlib.PyCdlib()
+    iso3.open_fp(out2)
+    check_udf_anchor_after_shrink(iso3, len(out2.getvalue()))
+    iso3.close()
+
 def test_new_rr_file_mode():
     iso = pycdlib.PyCdlib()
     iso.new(rock_ridge='1.09')


### PR DESCRIPTION
When I try to add a new file into a Windows 11 ISO using the following script:

```
import pycdlib

iso = pycdlib.PyCdlib()
iso.open('/Users/enzime/Downloads/26100.4349.250607-1500.ge_release_svc_refresh_CLIENTCONSUMER_RET_A64FRE_en-us.iso')
iso.add_file('/Users/enzime/Downloads/autounattend.xml', udf_path='/autounattend.xml')
iso.write('/Users/enzime/Downloads/Win11_unattended.iso')
iso.close()

iso = pycdlib.PyCdlib()
iso.open('/Users/enzime/Downloads/Win11_unattended.iso')

# Check UDF root for autounattend.xml
for child in iso.list_children(udf_path='/'):
    if child is None:
        continue
    if child.is_dot() or child.is_dotdot():
        continue
    name = child.file_identifier().decode('utf-8', errors='replace')
    print(name)

iso.close()

print('Done')
```

I would get the following error:

```
Traceback (most recent call last):
  File "<stdin>", line 10, in <module>
  File "/nix/store/187j0l8n5f1vwh85pq8fc78z5jqqf9ha-python3-3.13.11-env/lib/python3.13/site-packages/pycdlib/pycdlib.py", line 4066, in open
    self._open_fp(fp)
    ~~~~~~~~~~~~~^^^^
  File "/nix/store/187j0l8n5f1vwh85pq8fc78z5jqqf9ha-python3-3.13.11-env/lib/python3.13/site-packages/pycdlib/pycdlib.py", line 2319, in _open_fp
    self._parse_udf_descriptors()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/nix/store/187j0l8n5f1vwh85pq8fc78z5jqqf9ha-python3-3.13.11-env/lib/python3.13/site-packages/pycdlib/pycdlib.py", line 2017, in _parse_udf_descriptors
    raise pycdlibexception.PyCdlibInvalidISO('Expected at least 2 UDF Anchors')
pycdlib.pycdlibexception.PyCdlibInvalidISO: Expected at least 2 UDF Anchors
```

With this PR, the output ISO can be successfully opened and read:

```
boot
boot.catalog
bootmgr.efi
efi
setup.exe
sources
support
autounattend.xml
Done
```