### PR TITLE
Fix parsing the FreeBSD 14.3 ISO.

### DIFF
--- a/pycdlib/dr.py
+++ b/pycdlib/dr.py
@@ -83,7 +83,14 @@ class XARecord:
                 continue
 
             if unused != b'\x00\x00\x00\x00\x00':
-                raise pycdlibexception.PyCdlibInvalidISO('Unused fields should be 0')
+                # The signature looks like 'XA', but the trailing reserved
+                # bytes aren't zero.  A real XA record always has those zero
+                # per the Yellow Book spec, so this is a false positive: SUSP
+                # payload (Rock Ridge) coincidentally containing 'XA' at the
+                # signature offset.  Fall through to the next candidate
+                # offset, then to the for-else (return False) if neither
+                # candidate validates.
+                continue
 
             self._pad_size = offset
             break
@@ -183,8 +190,8 @@ class DirectoryRecord:
         self.xa_record = None  # type: Optional[XARecord]
         self.inode = None  # type: Optional[inode.Inode]
 
-    def parse(self, vd, record, parent):
-        # type: (headervd.PrimaryOrSupplementaryVD, bytes, Optional[DirectoryRecord]) -> str
+    def parse(self, vd, record, parent, xa=False):
+        # type: (headervd.PrimaryOrSupplementaryVD, bytes, Optional[DirectoryRecord], bool) -> str
         """
         Parse a directory record out of a string.
 
@@ -192,6 +199,11 @@ class DirectoryRecord:
          vd - The Volume Descriptor this record is part of.
          record - The string to parse for this record.
          parent - The parent of this record.
+         xa - Whether the volume declares XA (via the PVD's 'CD-XA001'
+              marker).  When False, the system-use area is not scanned for
+              an XA record; this avoids false-positive matches against
+              Rock Ridge SUSP payload that happens to contain the bytes
+              'XA' at the signature offset.
         Returns:
          The Rock Ridge version as a string if this Directory Record has Rock
          Ridge, '' otherwise.
@@ -278,10 +290,11 @@ class DirectoryRecord:
             self._printable_name = self.file_ident
 
         if self.parent is not None:
-            xa_rec = XARecord()
-            if xa_rec.parse(record[record_offset:], self.len_fi):
-                self.xa_record = xa_rec
-                record_offset += len(self.xa_record.record())
+            if xa:
+                xa_rec = XARecord()
+                if xa_rec.parse(record[record_offset:], self.len_fi):
+                    self.xa_record = xa_rec
+                    record_offset += len(self.xa_record.record())
 
             if len(record[record_offset:]) >= 2 and \
                record[record_offset:record_offset + 2] in (b'SP', b'RR', b'CE', b'PX', b'ER', b'ES', b'PN', b'SL', b'NM', b'CL', b'PL', b'TF', b'SF', b'RE', b'AL'):

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -1049,7 +1049,7 @@ class PyCdlib:
 
                 new_record = dr.DirectoryRecord()
                 rr = new_record.parse(vd, data[offset:offset + lenbyte],
-                                      dir_record)
+                                      dir_record, self.xa)
                 offset += lenbyte
 
                 # Cache some properties of this record for later use.

--- a/tests/unit/test_dr.py
+++ b/tests/unit/test_dr.py
@@ -24,10 +24,21 @@ def test_xa_parse_initialized_twice():
     assert(str(excinfo.value) == 'This XARecord is already initialized')
 
 def test_xa_parse_bad_reserved():
+    # Regression test for issue #136 (FreeBSD 14.3-BETA1).  When the bytes
+    # at the signature offset coincidentally equal 'XA' but the trailing
+    # reserved bytes are not all zero, this is not a real XA record (the
+    # Yellow Book spec mandates zero reserved bytes); it's Rock Ridge SUSP
+    # payload that happens to look like one.  Treat as not-XA, do not raise.
     xa = pycdlib.dr.XARecord()
-    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
-        xa.parse(b'\x00\x00\x00\x00\x00\x00\x58\x41\x00\x00\x00\x00\x00\x01', 1)
-    assert(str(excinfo.value) == 'Unused fields should be 0')
+    assert(not xa.parse(b'\x00\x00\x00\x00\x00\x00\x58\x41\x00\x00\x00\x00\x00\x01', 1))
+    assert(not xa._initialized)
+
+def test_xa_parse_no_signature():
+    # When neither candidate offset has the 'XA' signature, parse() returns
+    # False without initializing the record.
+    xa = pycdlib.dr.XARecord()
+    assert(not xa.parse(b'\x00' * 14, 1))
+    assert(not xa._initialized)
 
 def test_xa_parse_padding():
     xa = pycdlib.dr.XARecord()
@@ -77,6 +88,66 @@ def test_dr_bad_seqnum():
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
         dr.parse(None, b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' + b'\x00'*7 + b'\x00\x00\x00\x01\x00\x00\x02\x00\x00', None)
     assert(str(excinfo.value) == 'Little-endian and big-endian seqnum disagree')
+
+# A 33-byte directory record header for a non-root entry, plus a 1-byte
+# file_ident -- the same shape used by the dotdot tests above.  Length is
+# patched per-test to match the system-use payload that follows.
+_DR_HEADER_TEMPLATE = (
+    b'\x30'                                # dr_len (patched per-test)
+    b'\x00'                                # xattr_len
+    b'\x17\x00\x00\x00\x00\x00\x00\x17'    # extent_le / extent_be (swab)
+    b'\x00\x08\x00\x00\x00\x00\x08\x00'    # data_le / data_be (swab)
+    b'\x78\x09\x0d\x0d\x07\x15\xf0'        # date
+    b'\x02'                                # file_flags (DIR)
+    b'\x00\x00'                            # file_unit_size, interleave_gap_size
+    b'\x01\x00\x00\x01'                    # seqnum_le / seqnum_be (swab)
+    b'\x01'                                # len_fi=1
+    b'\x01'                                # file_ident (dotdot)
+)
+
+# 14 bytes that XARecord.parse will see at slice offset 0: bytes 6-7 are
+# 'XA' (signature match), bytes 9-13 are non-zero (would have raised the
+# old "Unused fields should be 0" error).  Bytes 0-1 (\xaa\xbb) are not
+# any known SUSP signature, so Rock Ridge detection is also skipped.
+_FAKE_XA_SYSUSE = b'\xaa\xbb\xcc\xdd\xee\xff' + b'XA' + b'\x00' + b'\x01\x02\x03\x04\x05'
+
+def _root_dr(pvd):
+    rec = pycdlib.dr.DirectoryRecord()
+    rec.parse(pvd, b'\x22\x00\x17\x00\x00\x00\x00\x00\x00\x17\x00\x08\x00\x00\x00\x00\x08\x00\x78\x09\x0d\x0d\x07\x15\xf0\x02\x00\x00\x01\x00\x00\x01\x01\x00', None)
+    return rec
+
+def test_dr_xa_skipped_when_no_marker():
+    # Regression test for issue #136 (FreeBSD 14.3-BETA1).  When the volume
+    # does not carry the 'CD-XA001' marker in the PVD application_use area,
+    # the parser must skip XA detection entirely.  Without the gate, a
+    # non-XA system-use payload that happens to contain 'XA' at the XA
+    # signature offset (byte 6 of the candidate slice) is misread as a
+    # malformed XA record and aborts the parse.
+    pvd = pycdlib.headervd.pvd_factory(b'', b'', 0, 0, 0, b'', b'', b'', b'', b'', b'', b'', 0.0, b'', False)
+    root = _root_dr(pvd)
+
+    record = _DR_HEADER_TEMPLATE + _FAKE_XA_SYSUSE
+
+    rec = pycdlib.dr.DirectoryRecord()
+    rec.parse(pvd, record, root, False)
+    assert(rec.xa_record is None)
+    assert(rec.rock_ridge is None)
+
+def test_dr_xa_marker_set_with_false_positive():
+    # Defensive layer beneath the architectural gate: even when the volume
+    # declares XA, a candidate slice whose signature bytes match 'XA' but
+    # whose trailing reserved bytes are not all zero must be treated as
+    # not-XA (per the Yellow Book spec, real XA records always have the
+    # reserved bytes zero), not as a malformed XA that aborts the parse.
+    pvd = pycdlib.headervd.pvd_factory(b'', b'', 0, 0, 0, b'', b'', b'', b'', b'', b'', b'', 0.0, b'', False)
+    root = _root_dr(pvd)
+
+    record = _DR_HEADER_TEMPLATE + _FAKE_XA_SYSUSE
+
+    rec = pycdlib.dr.DirectoryRecord()
+    rec.parse(pvd, record, root, True)
+    assert(rec.xa_record is None)
+    assert(rec.rock_ridge is None)
 
 def test_dr_bad_rr_parent():
     pvd = pycdlib.headervd.pvd_factory(b'', b'', 0, 0, 0, b'', b'', b'', b'', b'', b'', b'', 0.0, b'', False)


### PR DESCRIPTION
There are two layers to the fix:

1. Defensive (XARecord.parse): the unused != 0 case now continues instead of raising. Yellow Book spec says real XA records always have zero reserved bytes, so non-zero is evidence this isn't actually XA — fall through and try the next offset, then return False if neither validates.
2. Architectural (DirectoryRecord.parse): added xa=False parameter that gates the XARecord scan. The Rock Ridge detection that follows is left untouched at its original indentation level.

Fixes #136 