### PR TITLE
Add in fixes to support non-compliant VBox ISO.

### DIFF
--- a/pycdlib/rockridge.py
+++ b/pycdlib/rockridge.py
@@ -1579,8 +1579,12 @@ class RRNMRecord:
             raise pycdlibexception.PyCdlibInvalidISO('Invalid Rock Ridge NM flags')
 
         if name_len != 0:
-            if (self.posix_name_flags & (1 << 1)) or (self.posix_name_flags & (1 << 2)) or (self.posix_name_flags & (1 << 5)):
-                raise pycdlibexception.PyCdlibInvalidISO('Invalid name in Rock Ridge NM entry (0x%x %d)' % (self.posix_name_flags, name_len))
+            # The spec says CURRENT (bit 1), PARENT (bit 2), and HOST (bit 5)
+            # must not be combined with a name -- the flag itself is the
+            # entire payload.  ISOs in the wild (e.g. VirtualBox Guest
+            # Additions) violate this by setting CURRENT with a real name.
+            # When a name is present, take it; the bare flag was clearly
+            # not the writer's intent.
             self.posix_name += rrstr[5:5 + name_len]
 
         self._initialized = True
@@ -2529,12 +2533,13 @@ class RockRidge:
                     raise pycdlibexception.PyCdlibInvalidISO('Only single %s record supported' % (rtype.decode('utf-8')))
 
             if rtype == b'SP':
-                if left < 7 or not is_first_dir_record_of_root:
+                # SUSP says the SP record belongs in the first Directory
+                # Record of the root, but ISOs in the wild (e.g. VirtualBox
+                # Guest Additions) put one in every dot/dotdot DR.  Accept
+                # the record wherever it appears as long as there's room
+                # for one; RRSPRecord.parse() validates the magic bytes.
+                if left < 7:
                     raise pycdlibexception.PyCdlibInvalidISO('Invalid SUSP SP record')
-
-                # OK, this is the first Directory Record of the root
-                # directory, which means we should check it for the SUSP/RR
-                # extension, which is exactly 7 bytes and starts with 'SP'.
 
                 entry_list.sp_record = RRSPRecord()
                 entry_list.sp_record.parse(recslice)
@@ -3680,6 +3685,13 @@ class RockRidgeContinuationBlock:
         """
         newlen = offset + length - 1
         for entry in self._entries:
+            # Idempotent: if a previous DR already registered this exact
+            # range, accept silently.  Some writers (e.g. VirtualBox Guest
+            # Additions) share a single CE region across many dot/dotdot
+            # DRs to save space; each parses successfully and registers
+            # the same (offset, length) pair.
+            if entry.offset == offset and entry.length == length:
+                return
             thislen = entry.offset + entry.length - 1
             overlap = range(max(entry.offset, offset), min(thislen, newlen) + 1)
             if overlap:

--- a/tests/unit/test_rockridge.py
+++ b/tests/unit/test_rockridge.py
@@ -740,11 +740,16 @@ def test_rrnmrecord_parse_invalid_flag():
         nm.parse(b'NM\x05\x01\x03')
     assert(str(excinfo.value) == 'Invalid Rock Ridge NM flags')
 
-def test_rrnmrecord_parse_invalid_flag_with_name():
+def test_rrnmrecord_parse_flag_with_name_accepted():
+    # Regression test for issue #130: VirtualBox Guest Additions ISOs
+    # set the CURRENT (0x2) flag *and* include a name.  Per spec the two
+    # are mutually exclusive, but the name is the writer's clear intent;
+    # accept it rather than raising.  Pre-fix this raised
+    # 'Invalid name in Rock Ridge NM entry (0x2 1)'.
     nm = pycdlib.rockridge.RRNMRecord()
-    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
-        nm.parse(b'NM\x06\x01\x02a')
-    assert(str(excinfo.value) == 'Invalid name in Rock Ridge NM entry (0x2 1)')
+    nm.parse(b'NM\x06\x01\x02a')
+    assert(nm.posix_name == b'a')
+    assert(nm.posix_name_flags == 0x2)
 
 def test_rrnmrecord_new_double_initialized():
     nm = pycdlib.rockridge.RRNMRecord()
@@ -1103,6 +1108,15 @@ def test_rr_parse_invalid_sp_record():
         rr.parse(b'SP\x01\x01', False, 0, False, b'')
     assert(str(excinfo.value) == 'Invalid SUSP SP record')
 
+def test_rr_parse_sp_record_in_non_root_dr():
+    # Regression test for issue #130: VirtualBox Guest Additions ISOs put
+    # SP records in dot/dotdot DRs of non-root directories, not only in
+    # the root's first DR.  Pre-fix this raised 'Invalid SUSP SP record'
+    # whenever is_first_dir_record_of_root was False.
+    rr = pycdlib.rockridge.RockRidge()
+    rr.parse(b'SP\x07\x01\xbe\xef\x00', False, 0, False, b'')
+    assert(rr.dr_entries.sp_record is not None)
+
 def test_rr_parse_double_ce_record():
     rr = pycdlib.rockridge.RockRidge()
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
@@ -1441,6 +1455,16 @@ def test_rrcontentry_track_overlap():
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
         rr.track_entry(22, 33)
     assert(str(excinfo.value) == 'Overlapping CE regions on the ISO')
+
+def test_rrcontentry_track_exact_duplicate_idempotent():
+    # Regression test for issue #130: ISOs (e.g. VirtualBox Guest Additions)
+    # share a single CE region across many DRs to save space, so the parser
+    # sees the same (offset, length) registered repeatedly.  Treat
+    # exact-match re-registrations as idempotent rather than overlapping.
+    rr = pycdlib.rockridge.RockRidgeContinuationBlock(24, 2048)
+    rr.track_entry(0, 23)
+    rr.track_entry(0, 23)
+    assert(len(rr._entries) == 1)
 
 def test_rrcontentry_track_rest():
     rr = pycdlib.rockridge.RockRidgeContinuationBlock(24, 2048)


### PR DESCRIPTION
1. SP records outside the root's first DR (rockridge.py:2532). Pre-fix, pycdlib raised 'Invalid SUSP SP record' whenever it saw an SP record on any DR other than the root's . entry. The VBox writer puts SP in every dot/dotdot DR. The dropped check was purely a spec-compliance gate; the inner RRSPRecord.parse() already validates the magic bytes (0xBEEF) and length. Kept the left < 7 bounds check.

2. Duplicate CE region registration (rockridge.py:3671). Pre-fix, RockRidgeContinuationBlock.track_entry raised 'Overlapping CE regions on the ISO' whenever any range overlap was detected. The VBox writer shares one CE region (extent 28576, offset 0, length 319) across many DRs to save space, so the parser registers the exact same (offset, length) repeatedly. Treating exact-match registrations as idempotent (return without inserting); partial overlaps still raise.

3. NM record with CURRENT/PARENT/HOST flag and a name (rockridge.py:1582). Pre-fix, raised 'Invalid name in Rock Ridge NM entry (0x2 4)'. Per spec these flags are mutually exclusive with a name field, but VBox sets CURRENT (0x2) on a real name ('cert'). The name is unambiguously the writer's intent — accepting it; the flag is preserved as-is for downstream code.

Fixes #130 