### PR TITLE
Change how Rock Ridge gets detected.

### DIFF
--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -35,6 +35,7 @@ from pycdlib import isohybrid
 from pycdlib import path_table_record
 from pycdlib import pycdlibexception
 from pycdlib import pycdlibio
+from pycdlib import rockridge
 from pycdlib import udf as udfmod
 from pycdlib import utils
 
@@ -1021,6 +1022,13 @@ class PyCdlib:
         parent_links = []
         child_links = []
         lastbyte = 0
+        # Track whether we saw a Rock Ridge ER (Extension Reference) record
+        # whose ext_id identifies RRIP_1991A or IEEE_P1282.  Per SUSP/RRIP,
+        # that ER is the canonical declaration that the volume uses Rock
+        # Ridge.  Without it, any RR-shaped bytes we see in system-use areas
+        # are false positives (e.g. a Mac HFS-hybrid ISO whose system-use
+        # area happens to start with bytes matching an RR signature).
+        saw_rrip_er = False
         dirs = collections.deque([root_dir_record])
         while dirs:
             dir_record = dirs.popleft()
@@ -1138,6 +1146,11 @@ class PyCdlib:
                 # Rock Ridge version
                 self._set_rock_ridge(max(rr, rr_ce))
 
+                if not saw_rrip_er and new_record.rock_ridge is not None:
+                    er = new_record.rock_ridge.dr_entries.er_record or new_record.rock_ridge.ce_entries.er_record
+                    if er is not None and er.ext_id in (rockridge.EXT_ID_109, rockridge.EXT_ID_112):
+                        saw_rrip_er = True
+
                 if rr_cl:
                     child_links.append(new_record)
 
@@ -1192,6 +1205,17 @@ class PyCdlib:
                 cl.rock_ridge.cl_to_moved_dr = all_extent_to_dr[cl.rock_ridge.child_link_extent()]
                 if cl.rock_ridge.cl_to_moved_dr.rock_ridge is not None:
                     cl.rock_ridge.cl_to_moved_dr.rock_ridge.moved_to_cl_dr = cl
+
+        # If our per-record opportunistic detection set self.rock_ridge but
+        # no record carried a Rock Ridge ER record (RRIP_1991A or
+        # IEEE_P1282), the RR-shaped bytes were a false positive.  Treat
+        # the volume as non-Rock-Ridge so callers using rr_path get the
+        # clear "Cannot fetch a rr_path from a non-Rock Ridge ISO" error
+        # at the API boundary, rather than tripping deep inside walk()
+        # with "Cannot generate a Rock Ridge path on a non-Rock Ridge ISO"
+        # when an individual record doesn't have RR data.
+        if is_pvd and self.rock_ridge and not saw_rrip_er:
+            self.rock_ridge = ''
 
         return interchange_level, lastbyte
 

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2480,6 +2480,82 @@ def test_new_rr_onetwelve_px_in_ce():
 
     iso.close()
 
+def test_new_rr_intact_er_still_detected():
+    # Sanity: a normal Rock Ridge ISO with the canonical ER record present
+    # is still recognized as Rock Ridge after open.  Guards against the
+    # post-hoc detection in _walk_directories accidentally wiping out
+    # iso.rock_ridge for legitimate RR ISOs.
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.09')
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1', rr_name='foo')
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(io.BytesIO(out.getvalue()))
+    assert(iso2.rock_ridge == '1.09')
+    assert(iso2.has_rock_ridge())
+    iso2.close()
+
+def test_new_rr_missing_er_treated_as_non_rr():
+    # Regression test for https://github.com/clalancette/pycdlib/issues/123.
+    # A non-Rock-Ridge ISO can have system-use bytes that coincidentally
+    # match RR SUSP signatures (e.g. some MAC app ISOs).  Per-record
+    # opportunistic detection alone used to set iso.rock_ridge='1.09' from
+    # those false positives, and walk(rr_path=...) would later trip with
+    # "Cannot generate a Rock Ridge path on a non-Rock Ridge ISO" deep in
+    # the traversal when an individual record didn't have RR data.  The
+    # canonical RR signal is the ER record with ext_id 'RRIP_1991A' (or
+    # 'IEEE_P1282' for 1.12) -- without it, the volume is not RR.
+    #
+    # Build a real RR 1.09 ISO, then scrub the ER ext_id bytes so the ISO
+    # no longer declares RR via the canonical signal while leaving every
+    # per-record RR-shaped byte intact.
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.09')
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1', rr_name='foo')
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    data = bytearray(out.getvalue())
+    pos = data.find(b'RRIP_1991A')
+    assert(pos >= 0)
+    data[pos:pos + len(b'RRIP_1991A')] = b'XXXXXXXXXX'
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(io.BytesIO(bytes(data)))
+    assert(iso2.rock_ridge == '')
+    assert(not iso2.has_rock_ridge())
+    # rr_path now hits the API-boundary guard with a clear message
+    # instead of tripping deep inside walk().
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+        list(iso2.walk(rr_path='/'))
+    assert(str(excinfo.value) == 'Cannot fetch a rr_path from a non-Rock Ridge ISO')
+    iso2.close()
+
+def test_new_rr_onetwelve_missing_er_treated_as_non_rr():
+    # Same as test_new_rr_missing_er_treated_as_non_rr but for Rock Ridge
+    # 1.12, whose ER ext_id is IEEE_P1282 instead of RRIP_1991A.
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.12')
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1', rr_name='foo')
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    data = bytearray(out.getvalue())
+    pos = data.find(b'IEEE_P1282')
+    assert(pos >= 0)
+    data[pos:pos + len(b'IEEE_P1282')] = b'XXXXXXXXXX'
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(io.BytesIO(bytes(data)))
+    assert(iso2.rock_ridge == '')
+    assert(not iso2.has_rock_ridge())
+    iso2.close()
+
 def test_new_set_hidden_file():
     iso = pycdlib.PyCdlib()
     iso.new()


### PR DESCRIPTION
After each record RR data is finalized, check if it carries and ER record with an EXT_ID.  If so, set saw_rrip_er flag. Later on, if self.rock_ridge was set but saw_rrip_er is False, reset rock_ridge to empty (no Rock Ridge).

Fixes #123 