### PR TITLE
Fix modify_in_place corruption.

### DIFF
--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -4526,17 +4526,18 @@ class PyCdlib:
             utils.copy_data(data_len, self.logical_block_size, data_fp, self._cdfp)
             utils.zero_pad(self._cdfp, data_len, self.logical_block_size)
 
-        # Finally write out the directory record entry.
-        # This is a little tricky because of what things mean.  First of all,
-        # child.extents_to_here represents the total number of extents up to
-        # this child in the parent.  Thus, to get the absolute extent offset,
-        # we start with the parent's extent location, add on the number of
-        # extents to here, and remove 1 (since our offset will be zero-based).
-        # Second, child.offset_to_here is the *last* byte that the child uses,
-        # so to get the start of it we subtract off the length of the child.
-        # Then we can multiply the extent location by the logical block size,
-        # add on the offset, and get to the absolute location in the file.
+        # Finally update the directory record entries that reference this
+        # file with the new length.  For UDF the file entry has its own
+        # extent, so we can write it directly.  For ISO9660/Joliet the
+        # record lives inside its parent's directory extent; we used to
+        # compute that record's byte offset from extents_to_here /
+        # offset_to_here (which reflect pycdlib's in-memory sorted order
+        # of children), but the on-disk order doesn't always match the
+        # sorted order -- writing to the computed offset then corrupts
+        # whichever sibling actually sits at that on-disk position
+        # (issue #122).  Rewrite the parent's full child list instead.
         first_joliet = True
+        rewritten_parents = set()  # type: set
         for record, is_pvd_unused in child.inode.linked_records:
             if isinstance(record, dr.DirectoryRecord):
                 if self.joliet_vd is not None and id(record.vd) == id(self.joliet_vd) and first_joliet:
@@ -4545,18 +4546,44 @@ class PyCdlib:
                     self.joliet_vd.add_to_space_size(length)
                 if record.parent is None:
                     raise pycdlibexception.PyCdlibInternalError('Modifying file with empty parent')
-                abs_extent_loc = record.parent.extent_location() + record.extents_to_here - 1
-                offset = record.offset_to_here - record.dr_len
-                abs_offset = abs_extent_loc * self.logical_block_size + offset
+                record.set_data_length(length)
+                parent_id = id(record.parent)
+                if parent_id not in rewritten_parents:
+                    rewritten_parents.add(parent_id)
+                    self._rewrite_dir_record_extent(record.parent)
             elif isinstance(record, udfmod.UDFFileEntry):
+                record.set_data_length(length)
                 abs_offset = record.extent_location() * self.logical_block_size
+                self._cdfp.seek(abs_offset)
+                self._cdfp.write(record.record())
             else:
                 # This should never happen
                 raise pycdlibexception.PyCdlibInternalError('Invalid record type')
 
-            record.set_data_length(length)
-            self._cdfp.seek(abs_offset)
-            self._cdfp.write(record.record())
+    def _rewrite_dir_record_extent(self, parent):
+        # type: (dr.DirectoryRecord) -> None
+        """
+        Rewrite all of `parent`'s child directory records to disk in the
+        order pycdlib holds them in memory.  Used by modify_file_in_place
+        to avoid relying on per-record offsets that may be wrong if the
+        on-disk order doesn't match pycdlib's sorted order (issue #122).
+
+        Parameters:
+         parent - The parent DirectoryRecord whose children should be
+                  written out to disk.
+        Returns:
+         Nothing.
+        """
+        dir_extent = parent.extent_location()
+        offset_in_extent = 0
+        for ch in parent.children:
+            recstr = ch.record()
+            if offset_in_extent + len(recstr) > self.logical_block_size:
+                dir_extent += 1
+                offset_in_extent = 0
+            self._cdfp.seek(dir_extent * self.logical_block_size + offset_in_extent)
+            self._cdfp.write(recstr)
+            offset_in_extent += len(recstr)
 
     def add_hard_link(self, **kwargs):
         # type: (str) -> None

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2556,6 +2556,70 @@ def test_new_rr_onetwelve_missing_er_treated_as_non_rr():
     assert(not iso2.has_rock_ridge())
     iso2.close()
 
+def test_new_modify_file_in_place_unsorted_dir_records():
+    # Regression test for https://github.com/clalancette/pycdlib/issues/122.
+    # modify_file_in_place used to compute the on-disk byte offset of a
+    # directory record from extents_to_here / offset_to_here -- both
+    # derived from pycdlib's in-memory sorted order of children.  When
+    # the actual on-disk order doesn't match (some writers don't emit
+    # records strictly sorted), the write lands on the wrong byte range
+    # and silently corrupts whatever sibling actually sat at that offset.
+    # The fix rewrites the parent's full child list instead of trusting
+    # the per-record offset.
+    #
+    # Construct the on-disk vs in-memory skew by building a sorted ISO
+    # with three same-length-name files and swapping two of the records
+    # in the bytes.
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'AAA\n'), 4, '/AAA.;1')
+    iso.add_fp(io.BytesIO(b'BBB\n'), 4, '/BBB.;1')
+    iso.add_fp(io.BytesIO(b'CCC\n'), 4, '/CCC.;1')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    root_extent = iso.pvd.root_dir_record.extent_location()
+    iso.close()
+
+    # Locate the AAA and BBB records inside the root directory extent
+    # (layout: dot, dotdot, AAA, BBB, CCC) and swap their bytes so the
+    # on-disk order becomes dot, dotdot, BBB, AAA, CCC.
+    data = bytearray(out.getvalue())
+    pos = root_extent * 2048
+    pos += data[pos]   # skip dot
+    pos += data[pos]   # skip dotdot
+    aaa_pos = pos
+    aaa_len = data[aaa_pos]
+    bbb_pos = aaa_pos + aaa_len
+    bbb_len = data[bbb_pos]
+    assert(aaa_len == bbb_len)
+    aaa_bytes = bytes(data[aaa_pos:aaa_pos + aaa_len])
+    bbb_bytes = bytes(data[bbb_pos:bbb_pos + bbb_len])
+    data[aaa_pos:aaa_pos + aaa_len] = bbb_bytes
+    data[bbb_pos:bbb_pos + bbb_len] = aaa_bytes
+
+    # Re-open the patched ISO and modify AAA in place.  pycdlib reads
+    # records in on-disk order (BBB, AAA, CCC) but stores them sorted in
+    # memory (AAA, BBB, CCC) -- the divergence that triggers the bug.
+    fp = io.BytesIO(bytes(data))
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(fp)
+    iso2.modify_file_in_place(io.BytesIO(b'aaa\n'), 4, '/AAA.;1')
+    iso2.close()
+
+    # All three files must still be readable with their expected contents.
+    # Pre-fix, BBB or CCC would be corrupted by AAA's write hitting the
+    # wrong byte range.
+    iso3 = pycdlib.PyCdlib()
+    iso3.open_fp(fp)
+    for path, expected in [('/AAA.;1', b'aaa\n'),
+                           ('/BBB.;1', b'BBB\n'),
+                           ('/CCC.;1', b'CCC\n')]:
+        buf = io.BytesIO()
+        iso3.get_file_from_iso_fp(buf, iso_path=path)
+        assert(buf.getvalue() == expected)
+    iso3.close()
+
 def test_new_set_hidden_file():
     iso = pycdlib.PyCdlib()
     iso.new()


### PR DESCRIPTION
This can happen when the in-memory sorted order of children doesn't match the on-disk order of entries (the spec says they should be sorted, but not all
writers follow the spec).  The fix is to rewrite the parent's directory records together, which fixes it.

Fixes #86 