### PR TITLE
Support UDF Extended File Entries.

### DIFF
--- a/pycdlib/dr.py
+++ b/pycdlib/dr.py
@@ -340,8 +340,9 @@ class DirectoryRecord:
         return ret
 
     def _rr_new(self, rr_version, rr_name, rr_symlink_target, rr_relocated_child,
-                rr_relocated, rr_relocated_parent, file_mode, date_seconds):
-        # type: (str, bytes, bytes, bool, bool, bool, int, float) -> None
+                rr_relocated, rr_relocated_parent, file_mode, date_seconds,
+                creation_seconds=None):
+        # type: (str, bytes, bytes, bool, bool, bool, int, float, Optional[float]) -> None
         """
         Internal method to add Rock Ridge to a Directory Record.
 
@@ -376,7 +377,8 @@ class DirectoryRecord:
                                           file_mode, rr_symlink_target,
                                           rr_version, rr_relocated_child,
                                           rr_relocated, rr_relocated_parent,
-                                          bytes_to_skip, self.dr_len, {}, date_seconds)
+                                          bytes_to_skip, self.dr_len, {},
+                                          date_seconds, creation_seconds)
 
         # For files, we are done
         if not self.isdir:
@@ -522,8 +524,8 @@ class DirectoryRecord:
         self.initialized = True
 
     def new_symlink(self, vd, name, parent, rr_target, seqnum, rock_ridge,
-                    rr_name, xa, date_seconds):
-        # type: (headervd.PrimaryOrSupplementaryVD, bytes, DirectoryRecord, bytes, int, str, bytes, bool, float) -> None
+                    rr_name, xa, date_seconds, creation_seconds=None):
+        # type: (headervd.PrimaryOrSupplementaryVD, bytes, DirectoryRecord, bytes, int, str, bytes, bool, float, Optional[float]) -> None
         """
         Create a new symlink Directory Record.  This implies that the new
         record will be Rock Ridge.
@@ -539,6 +541,8 @@ class DirectoryRecord:
          xa - True if this is an Extended Attribute record.
          date_seconds - Time and date, in seconds since the epoch, to use for
                         this symlink.
+         creation_seconds - Optional creation time, in seconds since the epoch,
+                            for the Rock Ridge TF record.
         Returns:
          Nothing.
         """
@@ -548,11 +552,11 @@ class DirectoryRecord:
         self._new(vd, name, parent, seqnum, False, 0, xa, date_seconds)
         if rock_ridge:
             self._rr_new(rock_ridge, rr_name, rr_target, False, False, False,
-                         0o0120555, date_seconds)
+                         0o0120555, date_seconds, creation_seconds)
 
     def new_file(self, vd, length, isoname, parent, seqnum, rock_ridge, rr_name,
-                 xa, file_mode, date_seconds):
-        # type: (headervd.PrimaryOrSupplementaryVD, int, bytes, DirectoryRecord, int, str, bytes, bool, int, float) -> None
+                 xa, file_mode, date_seconds, creation_seconds=None):
+        # type: (headervd.PrimaryOrSupplementaryVD, int, bytes, DirectoryRecord, int, str, bytes, bool, int, float, Optional[float]) -> None
         """
         Create a new file Directory Record.
 
@@ -568,6 +572,8 @@ class DirectoryRecord:
          file_mode - The POSIX file mode for this entry.
          date_seconds - Time and date, in seconds since the epoch, to use for
                         this file.
+         creation_seconds - Optional creation time, in seconds since the epoch,
+                            for the Rock Ridge TF record.
         Returns:
          Nothing.
         """
@@ -577,7 +583,7 @@ class DirectoryRecord:
         self._new(vd, isoname, parent, seqnum, False, length, xa, date_seconds)
         if rock_ridge:
             self._rr_new(rock_ridge, rr_name, b'', False, False, False,
-                         file_mode, date_seconds)
+                         file_mode, date_seconds, creation_seconds)
 
     def new_root(self, vd, seqnum, log_block_size, date_seconds):
         # type: (headervd.PrimaryOrSupplementaryVD, int, int, float) -> None
@@ -656,8 +662,8 @@ class DirectoryRecord:
 
     def new_dir(self, vd, name, parent, seqnum, rock_ridge, rr_name,
                 log_block_size, rr_relocated_child, rr_relocated, xa, file_mode,
-                date_seconds):
-        # type: (headervd.PrimaryOrSupplementaryVD, bytes, DirectoryRecord, int, str, bytes, int, bool, bool, bool, int, float) -> None
+                date_seconds, creation_seconds=None):
+        # type: (headervd.PrimaryOrSupplementaryVD, bytes, DirectoryRecord, int, str, bytes, int, bool, bool, bool, int, float, Optional[float]) -> None
         """
         Create a new directory Directory Record.
 
@@ -675,6 +681,8 @@ class DirectoryRecord:
          file_mode - The POSIX file mode to set for this directory.
          date_seconds - Time and date, in seconds since the epoch, to use for
                         this directory record.
+         creation_seconds - Optional creation time, in seconds since the epoch,
+                            for the Rock Ridge TF record.
         Returns:
          Nothing.
         """
@@ -685,7 +693,8 @@ class DirectoryRecord:
                   date_seconds)
         if rock_ridge:
             self._rr_new(rock_ridge, rr_name, b'', rr_relocated_child,
-                         rr_relocated, False, file_mode, date_seconds)
+                         rr_relocated, False, file_mode, date_seconds,
+                         creation_seconds)
             if rr_relocated_child and self.rock_ridge:
                 # Relocated Rock Ridge entries are not exactly treated as
                 # directories, so fix things up here.

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -899,6 +899,33 @@ class PyCdlib:
 
         return (name.decode('utf-8').encode('utf-16_be'), parent)
 
+    def _new_udf_file_entry(self, parent, creation_time):
+        # type: (Optional[udfmod.UDFFileEntry], Optional[float]) -> udfmod.UDFFileEntry
+        """
+        An internal method to construct a fresh UDF file entry of the
+        appropriate on-disk format.  The choice between regular File Entry
+        (tag 261, ECMA-167 14.9) and Extended File Entry (tag 266, 14.17)
+        is per-entry, driven by:
+          - if the caller supplied a creation_time, EFE is required (FE has
+            no on-disk slot for it);
+          - otherwise the new entry mirrors its parent's on-disk format,
+            keeping pure-FE and pure-EFE ISOs round-trip-clean when adding
+            entries to an opened ISO.
+
+        Parameters:
+         parent - The parent UDF File Entry the new entry will live under,
+                  or None for the root.
+         creation_time - The user-supplied creation time, or None.
+        Returns:
+         A UDFFileEntry instance (or UDFExtendedFileEntry, which is-a
+         UDFFileEntry) ready to have .new() called on it.
+        """
+        if creation_time is not None:
+            return udfmod.UDFExtendedFileEntry()
+        if isinstance(parent, udfmod.UDFExtendedFileEntry):
+            return udfmod.UDFExtendedFileEntry()
+        return udfmod.UDFFileEntry()
+
     def _udf_name_and_parent_from_path(self, udf_path):
         # type: (bytes) -> Tuple[bytes, udfmod.UDFFileEntry]
         """
@@ -3080,8 +3107,8 @@ class PyCdlib:
             self._needs_reshuffle = True
 
     def _add_hard_link_to_inode(self, data_ino, length, file_mode,
-                                boot_catalog_old, **kwargs):
-        # type: (Optional[inode.Inode], int, int, bool, Optional[str]) -> int
+                                boot_catalog_old, creation_time, **kwargs):
+        # type: (Optional[inode.Inode], int, int, bool, Optional[float], Optional[str]) -> int
         """
         Add a hard link to the ISO.  Hard links are alternate names for the
         same file contents that don't take up any additional space on the ISO.
@@ -3162,7 +3189,7 @@ class PyCdlib:
             new_rec = dr.DirectoryRecord()
             new_rec.new_file(vd, length, new_name, new_parent,
                              vd.sequence_number(), rr, rr_name, xa, file_mode,
-                             time.time())
+                             time.time(), creation_time)
 
             num_bytes_to_add += self._add_child_to_dr(new_rec)
             num_bytes_to_add += self._update_rr_ce_entry(new_rec)
@@ -3179,8 +3206,13 @@ class PyCdlib:
                                                              self.logical_block_size)
             num_bytes_to_add += num_new_extents * self.logical_block_size
 
-            file_entry = udfmod.UDFFileEntry()
-            file_entry.new(length, 'file', udf_parent, self.logical_block_size)
+            file_entry = self._new_udf_file_entry(udf_parent, creation_time)
+            if isinstance(file_entry, udfmod.UDFExtendedFileEntry):
+                file_entry.new(length, 'file', udf_parent,
+                               self.logical_block_size, creation_time)
+            else:
+                file_entry.new(length, 'file', udf_parent,
+                               self.logical_block_size)
             file_ident.file_entry = file_entry
             file_entry.file_ident = file_ident
             if data_ino is None or data_ino.num_udf == 0:
@@ -3206,8 +3238,9 @@ class PyCdlib:
         return num_bytes_to_add
 
     def _add_fp(self, fp, length, manage_fp, iso_path, rr_name,
-                joliet_path, udf_path, file_mode, eltorito_catalog):
-        # type: (Optional[Union[BinaryIO, str]], int, bool, Optional[str], Optional[str], Optional[str], Optional[str], Optional[int], bool) -> int
+                joliet_path, udf_path, file_mode, eltorito_catalog,
+                creation_time):
+        # type: (Optional[Union[BinaryIO, str]], int, bool, Optional[str], Optional[str], Optional[str], Optional[str], Optional[int], bool, Optional[float]) -> int
         """
         An internal method to add a file to the ISO.  If the ISO contains Rock
         Ridge, then a Rock Ridge name must be provided.  If the ISO contains
@@ -3284,6 +3317,7 @@ class PyCdlib:
                 num_bytes_to_add += self._add_hard_link_to_inode(ino, thislen,
                                                                  fmode,
                                                                  eltorito_catalog,
+                                                                 creation_time,
                                                                  iso_new_path=iso_path,
                                                                  rr_name=rr_name)
 
@@ -3293,6 +3327,7 @@ class PyCdlib:
                 num_bytes_to_add += self._add_hard_link_to_inode(ino, thislen,
                                                                  fmode,
                                                                  eltorito_catalog,
+                                                                 creation_time,
                                                                  joliet_new_path=joliet_path)
 
             # This goes after the hard link so we only track the new Inode if
@@ -3309,6 +3344,7 @@ class PyCdlib:
             num_bytes_to_add += self._add_hard_link_to_inode(ino, length,
                                                              fmode,
                                                              eltorito_catalog,
+                                                             creation_time,
                                                              udf_new_path=udf_path)
 
         return num_bytes_to_add
@@ -4031,7 +4067,7 @@ class PyCdlib:
             num_bytes_to_add += 2 * self.logical_block_size
 
             # Create the root directory, and the 'parent' entry inside.
-            self.udf_root = udfmod.UDFFileEntry()
+            self.udf_root = self._new_udf_file_entry(None, None)
             self.udf_root.new(0, 'dir', None, self.logical_block_size)
             num_bytes_to_add += self.logical_block_size
 
@@ -4365,8 +4401,8 @@ class PyCdlib:
         self._write_fp(outfp, blocksize, progress_cb, progress_opaque)
 
     def add_fp(self, fp, length, iso_path=None, rr_name=None, joliet_path=None,
-               file_mode=None, udf_path=None):
-        # type: (BinaryIO, int, Optional[str], Optional[str], Optional[str], Optional[int], Optional[str]) -> None
+               file_mode=None, udf_path=None, creation_time=None):
+        # type: (BinaryIO, int, Optional[str], Optional[str], Optional[str], Optional[int], Optional[str], Optional[float]) -> None
         """
         Add a file to the ISO.  If the ISO is a Rock Ridge one, then a Rock
         Ridge name must also be provided.  If the ISO is a Joliet one, then a
@@ -4386,6 +4422,13 @@ class PyCdlib:
                      applies if this is a Rock Ridge ISO.  If this is None (the
                      default), the permissions from the original file are used.
          udf_path - The UDF name of the file destination on the ISO.
+         creation_time - Optional creation time, in seconds since the epoch.
+                         Stored on Rock Ridge TF (CREATION timestamp) and on
+                         UDF (forces an Extended File Entry, which has the
+                         on-disk slot).  Plain ISO9660 and Joliet have no
+                         creation-time field, so when supplied this value
+                         requires that at least one of iso_path (with Rock
+                         Ridge enabled) or udf_path is also supplied.
         Returns:
          Nothing.
         """
@@ -4395,14 +4438,19 @@ class PyCdlib:
         if not utils.file_object_supports_binary(fp):
             raise pycdlibexception.PyCdlibInvalidInput('The fp argument must be in binary mode')
 
+        if creation_time is not None and not ((iso_path and self.rock_ridge) or udf_path):
+            raise pycdlibexception.PyCdlibInvalidInput(
+                'creation_time can only be stored on a Rock Ridge iso_path or a udf_path')
+
         num_bytes_to_add = self._add_fp(fp, length, False, iso_path, rr_name,
-                                        joliet_path, udf_path, file_mode, False)
+                                        joliet_path, udf_path, file_mode, False,
+                                        creation_time)
 
         self._finish_add(0, num_bytes_to_add)
 
     def add_file(self, filename, iso_path=None, rr_name=None, joliet_path=None,
-                 file_mode=None, udf_path=None):
-        # type: (str, Optional[str], Optional[str], Optional[str], Optional[int], Optional[str]) -> None
+                 file_mode=None, udf_path=None, creation_time=None):
+        # type: (str, Optional[str], Optional[str], Optional[str], Optional[int], Optional[str], Optional[float]) -> None
         """
         Add a file to the ISO.  If the ISO is a Rock Ridge one, then a Rock
         Ridge name must also be provided.  If the ISO is a Joliet one, then a
@@ -4418,15 +4466,22 @@ class PyCdlib:
                      applies if this is a Rock Ridge ISO.  If this is None (the
                      default), the permissions from the original file are used.
          udf_path - The UDF name of the file destination on the ISO.
+         creation_time - Optional creation time, in seconds since the epoch.
+                         See add_fp for storage rules.
         Returns:
          Nothing.
         """
         if not self._initialized:
             raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
 
+        if creation_time is not None and not ((iso_path and self.rock_ridge) or udf_path):
+            raise pycdlibexception.PyCdlibInvalidInput(
+                'creation_time can only be stored on a Rock Ridge iso_path or a udf_path')
+
         num_bytes_to_add = self._add_fp(filename, os.stat(filename).st_size,
                                         True, iso_path, rr_name, joliet_path,
-                                        udf_path, file_mode, False)
+                                        udf_path, file_mode, False,
+                                        creation_time)
 
         self._finish_add(0, num_bytes_to_add)
 
@@ -4586,7 +4641,7 @@ class PyCdlib:
             offset_in_extent += len(recstr)
 
     def add_hard_link(self, **kwargs):
-        # type: (str) -> None
+        # type: (...) -> None
         """
         Add a hard link to the ISO.  Hard links are alternate names for the
         same file contents that don't take up any additional space on the the
@@ -4610,6 +4665,10 @@ class PyCdlib:
          boot_catalog_old - Use the El Torito boot catalog as the old path.
          udf_old_path - The old path on the UDF filesystem to link from.
          udf_new_path - The new path on the UDF filesystem to link to.
+         creation_time - Optional creation time, in seconds since the epoch,
+                         for the newly-created link.  See add_fp for storage
+                         rules: requires iso_new_path on a Rock Ridge ISO or
+                         udf_new_path.
         Returns:
          Nothing.
         """
@@ -4621,6 +4680,7 @@ class PyCdlib:
         joliet_old_path = None
         boot_catalog_old = False
         udf_old_path = None
+        creation_time = None  # type: Optional[float]
         keys_to_remove = []
         for key, value in kwargs.items():
             if key == 'iso_old_path':
@@ -4645,9 +4705,27 @@ class PyCdlib:
                     num_old += 1
                     udf_old_path = utils.normpath(value)
                 keys_to_remove.append(key)
+            elif key == 'creation_time':
+                creation_time = value
+                keys_to_remove.append(key)
 
         if num_old != 1:
             raise pycdlibexception.PyCdlibInvalidInput('Exactly one old path must be specified')
+
+        iso_new_path = kwargs.get('iso_new_path')
+        udf_new_path = kwargs.get('udf_new_path')
+        if creation_time is not None:
+            if udf_new_path is not None:
+                # In pycdlib's UDF writer, hard links to the same inode
+                # share a single on-disk File Entry, so a per-link
+                # creation_time would silently overwrite the shared
+                # entry's timestamp.  Reject it rather than pretend it
+                # works.
+                raise pycdlibexception.PyCdlibInvalidInput(
+                    'creation_time is not supported on UDF hard links; set creation_time when the file is first added')
+            if not (iso_new_path and self.rock_ridge):
+                raise pycdlibexception.PyCdlibInvalidInput(
+                    'creation_time can only be stored on a Rock Ridge iso_new_path')
 
         # Once we've iterated over the keys we know about, remove them from
         # the map so that _add_hard_link_to_inode() can parse the rest.
@@ -4689,6 +4767,7 @@ class PyCdlib:
         num_bytes_to_add = self._add_hard_link_to_inode(old_rec.inode,
                                                         old_rec.get_data_length(),
                                                         fmode, boot_catalog_old,
+                                                        creation_time,
                                                         **kwargs)
 
         self._finish_add(0, num_bytes_to_add)
@@ -4756,8 +4835,8 @@ class PyCdlib:
         self._finish_remove(num_bytes_to_remove, True)
 
     def add_directory(self, iso_path=None, rr_name=None, joliet_path=None,
-                      file_mode=None, udf_path=None):
-        # type: (Optional[str], Optional[str], Optional[str], Optional[int], Optional[str]) -> None
+                      file_mode=None, udf_path=None, creation_time=None):
+        # type: (Optional[str], Optional[str], Optional[str], Optional[int], Optional[str], Optional[float]) -> None
         """
         Add a directory to the ISO.  At least one of an iso_path, joliet_path,
         or udf_path must be provided.  Providing joliet_path on a non-Joliet
@@ -4771,6 +4850,8 @@ class PyCdlib:
          file_mode - The POSIX file mode to use for the directory.  This only
                      applies for Rock Ridge ISOs.
          udf_path - The UDF absolute path to use for the directory.
+         creation_time - Optional creation time, in seconds since the epoch.
+                         See add_fp for storage rules.
         Returns:
          Nothing.
         """
@@ -4782,6 +4863,10 @@ class PyCdlib:
 
         if file_mode is not None and not self.rock_ridge:
             raise pycdlibexception.PyCdlibInvalidInput('A file mode can only be specified for Rock Ridge ISOs')
+
+        if creation_time is not None and not ((iso_path and self.rock_ridge) or udf_path):
+            raise pycdlibexception.PyCdlibInvalidInput(
+                'creation_time can only be stored on a Rock Ridge iso_path or a udf_path')
 
         # For backwards-compatibility reasons, if the mode was not specified we
         # just assume 555.  We should probably eventually make file_mode
@@ -4822,7 +4907,8 @@ class PyCdlib:
                                      self.pvd.sequence_number(),
                                      self.rock_ridge, new_rr_name,
                                      self.logical_block_size, True, False,
-                                     self.xa, file_mode, time.time())
+                                     self.xa, file_mode, time.time(),
+                                     creation_time)
                 num_bytes_to_add += self._add_child_to_dr(fake_dir_rec)
 
                 # The fake dir record doesn't get an entry in the path table
@@ -4853,7 +4939,7 @@ class PyCdlib:
             rec.new_dir(self.pvd, iso9660_name, parent,
                         self.pvd.sequence_number(), self.rock_ridge, new_rr_name,
                         self.logical_block_size, False, relocated,
-                        self.xa, file_mode, time.time())
+                        self.xa, file_mode, time.time(), creation_time)
             num_bytes_to_add += self._add_child_to_dr(rec)
             if rec.rock_ridge is not None:
                 if relocated and fake_dir_rec is not None and fake_dir_rec.rock_ridge is not None:
@@ -4898,8 +4984,12 @@ class PyCdlib:
             num_new_extents = udf_parent.add_file_ident_desc(file_ident, self.logical_block_size)
             num_bytes_to_add += num_new_extents * self.logical_block_size
 
-            file_entry = udfmod.UDFFileEntry()
-            file_entry.new(0, 'dir', udf_parent, self.logical_block_size)
+            file_entry = self._new_udf_file_entry(udf_parent, creation_time)
+            if isinstance(file_entry, udfmod.UDFExtendedFileEntry):
+                file_entry.new(0, 'dir', udf_parent, self.logical_block_size,
+                               creation_time)
+            else:
+                file_entry.new(0, 'dir', udf_parent, self.logical_block_size)
             file_ident.file_entry = file_entry
             file_entry.file_ident = file_ident
             num_bytes_to_add += self.logical_block_size
@@ -5231,7 +5321,7 @@ class PyCdlib:
             num_bytes_to_add += self._add_fp(None, self.logical_block_size,
                                              False, bootcatfile, rrname,
                                              joliet_bootcatfile,
-                                             udf_bootcatfile, None, True)
+                                             udf_bootcatfile, None, True, None)
 
         self._finish_add(0, num_bytes_to_add)
 
@@ -5301,8 +5391,9 @@ class PyCdlib:
         self._finish_remove(num_bytes_to_remove, True)
 
     def add_symlink(self, symlink_path=None, rr_symlink_name=None, rr_path=None,
-                    joliet_path=None, udf_symlink_path=None, udf_target=None):
-        # type: (Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]) -> None
+                    joliet_path=None, udf_symlink_path=None, udf_target=None,
+                    creation_time=None):
+        # type: (Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[float]) -> None
         """
         Add a symlink from rr_symlink_name to the rr_path.  The ISO must have
         either Rock Ridge or UDF support (or both).
@@ -5316,6 +5407,11 @@ class PyCdlib:
          udf_symlink_path - The UDF path of the symlink itself on the ISO.
          udf_target - The UDF name of the entry on the ISO that the symlink
                       points to.
+         creation_time - Optional creation time, in seconds since the epoch.
+                         See add_fp for storage rules.  At least one of a Rock
+                         Ridge symlink (rr_symlink_name + rr_path) or a UDF
+                         symlink (udf_symlink_path + udf_target) must be
+                         supplied to store it.
         Returns:
          Nothing.
         """
@@ -5385,6 +5481,13 @@ class PyCdlib:
             # Rule 9
             raise pycdlibexception.PyCdlibInvalidInput('A Joliet path can only be specified for a Joliet ISO')
 
+        if creation_time is not None and rr_vars_provided != 2 and udf_vars_provided != 2:
+            # Both ends of an RR symlink must be present for the TF record
+            # to apply; either rr-symlink or udf-symlink can store
+            # creation_time.
+            raise pycdlibexception.PyCdlibInvalidInput(
+                'creation_time on add_symlink requires either a Rock Ridge symlink (rr_symlink_name + rr_path) or a UDF symlink (udf_symlink_path + udf_target)')
+
         # Checks complete, we can go on to make the symlink.
 
         num_bytes_to_add = 0
@@ -5402,7 +5505,8 @@ class PyCdlib:
                 rr_symlink_name_bytes = rr_symlink_name.encode('utf-8')
                 rec.new_symlink(self.pvd, name, parent, rr_path.encode('utf-8'),
                                 self.pvd.sequence_number(), self.rock_ridge,
-                                rr_symlink_name_bytes, self.xa, time.time())
+                                rr_symlink_name_bytes, self.xa, time.time(),
+                                creation_time)
                 num_bytes_to_add += self._add_child_to_dr(rec)
 
                 num_bytes_to_add += self._update_rr_ce_entry(rec)
@@ -5416,7 +5520,7 @@ class PyCdlib:
                     tmp_joliet_path = ''
                 num_bytes_to_add += self._add_fp(None, 0, False, symlink_path,
                                                  '', tmp_joliet_path, '', None,
-                                                 False)
+                                                 False, creation_time)
 
             udf_symlink_path_bytes = utils.normpath(udf_symlink_path)
 
@@ -5432,9 +5536,13 @@ class PyCdlib:
             # Generate the bytearry representing the symlink.
             symlink_bytearray = udfmod.symlink_to_bytes(udf_target)
 
-            file_entry = udfmod.UDFFileEntry()
-            file_entry.new(len(symlink_bytearray), 'symlink', udf_parent,
-                           self.logical_block_size)
+            file_entry = self._new_udf_file_entry(udf_parent, creation_time)
+            if isinstance(file_entry, udfmod.UDFExtendedFileEntry):
+                file_entry.new(len(symlink_bytearray), 'symlink', udf_parent,
+                               self.logical_block_size, creation_time)
+            else:
+                file_entry.new(len(symlink_bytearray), 'symlink', udf_parent,
+                               self.logical_block_size)
             file_ident.file_entry = file_entry
             file_entry.file_ident = file_ident
             num_bytes_to_add += self.logical_block_size

--- a/pycdlib/rockridge.py
+++ b/pycdlib/rockridge.py
@@ -1933,20 +1933,28 @@ class RRTFRecord:
 
         self._initialized = True
 
-    def new(self, time_flags, date_seconds):
-        # type: (int, float) -> None
+    def new(self, time_flags, date_seconds, creation_seconds=None):
+        # type: (int, float, Optional[float]) -> None
         """
         Create a new Rock Ridge Time Stamp record.
 
         Parameters:
          time_flags - The flags to use for this time stamp record.
          date_seconds - Time and date, in seconds since the epoch, to use for
-                        this time stamp record.
+                        each enabled timestamp field.
+         creation_seconds - Time and date, in seconds since the epoch, to use
+                            specifically for the creation_time field.  When
+                            provided, the creation_time bit is forced on in
+                            time_flags and the field is populated from this
+                            value rather than from date_seconds.
         Returns:
          Nothing.
         """
         if self._initialized:
             raise pycdlibexception.PyCdlibInternalError('TF record already initialized')
+
+        if creation_seconds is not None:
+            time_flags |= 0x01
 
         self.time_flags = time_flags
 
@@ -1960,7 +1968,10 @@ class RRTFRecord:
                     setattr(self, fieldname, dates.DirectoryRecordDate())
                 elif tflen == 17:
                     setattr(self, fieldname, dates.VolumeDescriptorDate())
-                getattr(self, fieldname).new(date_seconds)
+                if fieldname == 'creation_time' and creation_seconds is not None:
+                    getattr(self, fieldname).new(creation_seconds)
+                else:
+                    getattr(self, fieldname).new(date_seconds)
 
         self._initialized = True
 
@@ -3006,8 +3017,8 @@ class RockRidge:
     def _assign_entries(self, is_first_dir_record_of_root, rr_name, file_mode,
                         symlink_path, rr_relocated_child, rr_relocated,
                         rr_relocated_parent, bytes_to_skip, curr_dr_len,
-                        attributes, date_seconds):
-        # type: (bool, bytes, int, bytes, bool, bool, bool, int, int, Dict[bytes, bytes], float) -> int
+                        attributes, date_seconds, creation_seconds=None):
+        # type: (bool, bytes, int, bytes, bool, bool, bool, int, int, Dict[bytes, bytes], float, Optional[float]) -> int
         """
         Assign Rock Ridge entries to the appropriate DR or CE record.
 
@@ -3107,9 +3118,12 @@ class RockRidge:
                 rr_record.append_field('SL')
 
         # For TF record
+        tf_flags = TF_FLAGS
+        if creation_seconds is not None:
+            tf_flags |= 0x01
         new_tf = RRTFRecord()
-        new_tf.new(TF_FLAGS, date_seconds)
-        thislen = RRTFRecord.length(TF_FLAGS)
+        new_tf.new(tf_flags, date_seconds, creation_seconds)
+        thislen = RRTFRecord.length(tf_flags)
         if curr_dr_len + thislen > ALLOWED_DR_SIZE:
             if self.dr_entries.ce_record is None:
                 return -1
@@ -3204,8 +3218,8 @@ class RockRidge:
     def new(self, is_first_dir_record_of_root, rr_name, file_mode,
             symlink_path, rr_version, rr_relocated_child, rr_relocated,
             rr_relocated_parent, bytes_to_skip, curr_dr_len, attributes,
-            date_seconds):
-        # type: (bool, bytes, int, bytes, str, bool, bool, bool, int, int, Dict[bytes, bytes], float) -> int
+            date_seconds, creation_seconds=None):
+        # type: (bool, bytes, int, bytes, str, bool, bool, bool, int, int, Dict[bytes, bytes], float, Optional[float]) -> int
         """
         Create a new Rock Ridge record.
 
@@ -3246,7 +3260,8 @@ class RockRidge:
                                           file_mode, symlink_path,
                                           rr_relocated_child, rr_relocated,
                                           rr_relocated_parent, bytes_to_skip,
-                                          curr_dr_len, attributes, date_seconds)
+                                          curr_dr_len, attributes, date_seconds,
+                                          creation_seconds)
 
         if new_dr_len < 0:
             self.dr_entries = RockRidgeEntries()

--- a/pycdlib/udf.py
+++ b/pycdlib/udf.py
@@ -5318,50 +5318,63 @@ class UDFPartitionIntegrityEntry:
         self._initialized = True
 
 
-class UDFExtendedFileEntry:
-    """A class representing a UDF Extended File Entry (ECMA-167, Part 4, 14.17)."""
-    __slots__ = ('_initialized', 'uid', 'gid', 'permissions', 'file_link_count',
-                 'record_format', 'record_display_attrs', 'record_len',
-                 'info_len', 'obj_size', 'log_blocks_recorded',
-                 'access_time', 'mod_time', 'creation_time', 'impl_ident',
-                 'attr_time', 'checkpoint', 'extended_attr_icb',
-                 'stream_icb', 'extended_attrs', 'unique_id', 'alloc_descs',
-                 'len_extended_attrs', 'icb_tag', 'desc_tag')
+class UDFExtendedFileEntry(UDFFileEntry):
+    """A class representing a UDF Extended File Entry (ECMA-167, Part 4, 14.17).
+
+    Extended File Entry is a superset of regular File Entry (14.9) per the
+    spec, allowed since UDF 2.00.  This class inherits the entire runtime
+    interface (extent_location, add_file_ident_desc, is_dir, ...) and only
+    overrides parse() and record() for the distinct on-disk layout, plus
+    extends __slots__ for the EFE-only fields.
+    """
+    __slots__ = ('obj_size', 'creation_time', 'stream_icb')
 
     FMT = '<16s20sLLLHBBLQQQ12s12s12s12sL4s16s16s32sQLL'
 
     def __init__(self):
         # type: () -> None
-        self.alloc_descs = []  # type: List[Union[UDFShortAD, UDFLongAD, UDFInlineAD]]
-        self._initialized = False
+        UDFFileEntry.__init__(self)
+        self.obj_size = 0
+        self.creation_time = UDFTimestamp()
+        self.stream_icb = UDFLongAD()
 
-    def parse(self, data, extent, desc_tag):
-        # type: (bytes, int, UDFTag) -> None
+    def parse(self, data, extent, parent, desc_tag):
+        # type: (bytes, int, Optional[UDFFileEntry], UDFTag) -> None
         """
         Parse the passed in data into a UDF Extended File Entry.
 
         Parameters:
          data - The data to parse.
-         extent - The extent this Extended File Entry lives at.
-         desc_tag - The UDF Tag associated with this UDF Extended File Entry.
+         extent - The extent that this descriptor currently lives at.
+         parent - The parent File Entry for this file (may be None).
+         desc_tag - A UDFTag object that represents the Descriptor Tag.
         Returns:
          Nothing.
         """
         if self._initialized:
             raise pycdlibexception.PyCdlibInternalError('UDF Extended File Entry already initialized')
 
-        (tag_unused, icb_tag, self.uid, self.gid, self.permissions,
-         self.file_link_count, self.record_format, self.record_display_attrs,
-         self.record_len, self.info_len, self.obj_size, self.log_blocks_recorded,
-         access_time, mod_time, creation_time, attr_time,
-         self.checkpoint, reserved_unused, extended_attr_icb, stream_icb,
-         impl_ident, self.unique_id, self.len_extended_attrs,
+        (tag_unused, icb_tag, self.uid, self.gid, self.perms,
+         self.file_link_count, record_format, record_display_attrs,
+         record_len, self.info_len, self.obj_size, self.log_block_recorded,
+         access_time, mod_time, creation_time, attr_time, checkpoint,
+         reserved_unused, extended_attr_icb, stream_icb, impl_ident,
+         self.unique_id, self.len_extended_attrs,
          len_alloc_descs) = struct.unpack_from(self.FMT, data, 0)
 
         self.desc_tag = desc_tag
 
         self.icb_tag = UDFICBTag()
         self.icb_tag.parse(icb_tag)
+
+        if record_format != 0:
+            raise pycdlibexception.PyCdlibInvalidISO('File Entry record format is not 0')
+
+        if record_display_attrs != 0:
+            raise pycdlibexception.PyCdlibInvalidISO('File Entry record display attributes is not 0')
+
+        if record_len != 0:
+            raise pycdlibexception.PyCdlibInvalidISO('File Entry record length is not 0')
 
         self.access_time = UDFTimestamp()
         self.access_time.parse(access_time)
@@ -5374,6 +5387,9 @@ class UDFExtendedFileEntry:
 
         self.attr_time = UDFTimestamp()
         self.attr_time.parse(attr_time)
+
+        if checkpoint != 1:
+            raise pycdlibexception.PyCdlibInvalidISO('Only DVD Read-only disks supported')
 
         self.extended_attr_icb = UDFLongAD()
         self.extended_attr_icb.parse(extended_attr_icb)
@@ -5393,6 +5409,9 @@ class UDFExtendedFileEntry:
                                                          data[offset:],
                                                          len_alloc_descs,
                                                          offset, extent)
+        self.orig_extent_loc = extent
+
+        self.parent = parent
 
         self._initialized = True
 
@@ -5415,101 +5434,54 @@ class UDFExtendedFileEntry:
 
         rec = struct.pack(self.FMT, b'\x00' * 16,
                           self.icb_tag.record(), self.uid, self.gid,
-                          self.permissions, self.file_link_count,
-                          self.record_format, self.record_display_attrs,
-                          self.record_len, self.info_len, self.obj_size,
-                          self.log_blocks_recorded, self.access_time.record(),
-                          self.mod_time.record(), self.creation_time.record(),
-                          self.attr_time.record(), self.checkpoint, b'\x00' * 4,
+                          self.perms, self.file_link_count, 0, 0, 0,
+                          self.info_len, self.obj_size,
+                          self.log_block_recorded,
+                          self.access_time.record(),
+                          self.mod_time.record(),
+                          self.creation_time.record(),
+                          self.attr_time.record(), 1, b'\x00' * 4,
                           self.extended_attr_icb.record(),
-                          self.stream_icb.record(), self.impl_ident.record(),
-                          self.unique_id, self.len_extended_attrs,
-                          len_alloc_descs)[16:]
+                          self.stream_icb.record(),
+                          self.impl_ident.record(), self.unique_id,
+                          self.len_extended_attrs, len_alloc_descs)[16:]
         rec += self.extended_attrs
         for desc in self.alloc_descs:
             rec += desc.record()
 
         return self.desc_tag.record(rec) + rec
 
-    def new(self, file_type, length, log_block_size):
-        # type: (str, int, int) -> None
+    def new(self, length, file_type, parent, log_block_size, creation_seconds=None):
+        # type: (int, str, Optional[UDFFileEntry], int, Optional[float]) -> None
         """
-        Create a new UDF Extended File Entry.
+        Create a new UDF Extended File Entry.  Reuses UDFFileEntry.new() for
+        the shared fields, then overrides the descriptor tag to be 266 and
+        initializes the EFE-only fields.
 
         Parameters:
-         file_type - The type that this UDF Space Entry represents; one of
-                     'dir', 'file', or 'symlink'.
          length - The (starting) length of this UDF File Entry; this is ignored
                   if this is a symlink.
+         file_type - The type that this UDF File entry represents; one of 'dir',
+                     'file', or 'symlink'.
+         parent - The parent UDF File Entry for this UDF File Entry.
          log_block_size - The logical block size for extents.
+         creation_seconds - Time and date, in seconds since the epoch, to use
+                            for the EFE creation_time field.  Defaults to the
+                            current time when omitted.
         Returns:
          Nothing.
         """
-        if self._initialized:
-            raise pycdlibexception.PyCdlibInternalError('UDF Extended File Entry already initialized')
-
+        UDFFileEntry.new(self, length, file_type, parent, log_block_size)
         self.desc_tag = UDFTag()
         self.desc_tag.new(266)  # FIXME: let the user set serial_number
 
-        self.icb_tag = UDFICBTag()
-        self.icb_tag.new(file_type)
-
-        self.uid = 4294967295  # Really -1, which means unset
-        self.gid = 4294967295  # Really -1, which means unset
-        if file_type == 'dir':
-            self.permissions = 5285
-            self.file_link_count = 0
-            self.info_len = 0
-            self.log_blocks_recorded = 1
-            # The position is bogus, but will get set
-            # properly once reshuffle_extents is called.
-            short_ad = UDFShortAD()
-            short_ad.new(length)
-            self.alloc_descs.append(short_ad)
-        else:
-            self.permissions = 4228
-            self.file_link_count = 1
-            self.info_len = length
-            self.log_blocks_recorded = utils.ceiling_div(length, log_block_size)
-            len_left = length
-            while len_left > 0:
-                # According to Ecma-167 14.14.1.1, the least-significant 30 bits
-                # of the allocation descriptor length field specify the length
-                # (the most significant two bits are properties which we don't
-                # currently support).  In theory we should then split files
-                # into 2^30 = 0x40000000, but all implementations I've seen
-                # split it into smaller.  cdrkit/cdrtools uses 0x3ffff800, and
-                # Windows uses 0x3ff00000.  To be more compatible with cdrkit,
-                # we'll choose their number of 0x3ffff800.
-                alloc_len = min(len_left, 0x3ffff800)
-                # The position is bogus, but will get set
-                # properly once reshuffle_extents is called.
-                short_ad = UDFShortAD()
-                short_ad.new(alloc_len)
-                self.alloc_descs.append(short_ad)
-                len_left -= alloc_len
-
-        self.access_time = UDFTimestamp()
-        self.access_time.new(time.time())
-
-        self.mod_time = UDFTimestamp()
-        self.mod_time.new(time.time())
-
-        self.attr_time = UDFTimestamp()
-        self.attr_time.new(time.time())
-
-        self.extended_attr_icb = UDFLongAD()
-        self.extended_attr_icb.new(0, 0)
-
-        self.impl_ident = UDFEntityID()
-        self.impl_ident.new(0, b'*pycdlib')
-
-        self.unique_id = 0  # this will get set later
-        self.len_extended_attrs = 0  # FIXME: let the user set this
-
-        self.extended_attrs = b''
-
-        self._initialized = True
+        self.obj_size = self.info_len
+        self.creation_time = UDFTimestamp()
+        if creation_seconds is None:
+            creation_seconds = time.time()
+        self.creation_time.new(creation_seconds)
+        self.stream_icb = UDFLongAD()
+        self.stream_icb.new(0, 0)
 
 
 def symlink_to_bytes(symlink_target):
@@ -5855,8 +5827,11 @@ def parse_file_set(file_set_and_term_data, current_extent, logical_block_size):
 def parse_file_entry(icbdata, abs_file_entry_extent, icb_log_block_num, parent):
     # type: (bytes, int, int, Optional[UDFFileEntry]) -> Optional[UDFFileEntry]
     """
-    An internal method to parse a single UDF File Entry and return the
-    corresponding object.
+    An internal method to parse a single UDF File Entry or Extended File
+    Entry and return the corresponding object.  The on-disk format is
+    chosen by the descriptor tag identifier: 261 maps to UDFFileEntry
+    (ECMA-167 14.9), 266 maps to UDFExtendedFileEntry (ECMA-167 14.17,
+    a subclass of UDFFileEntry).
 
     Parameters:
      icbdata - The data to parse.
@@ -5864,7 +5839,8 @@ def parse_file_entry(icbdata, abs_file_entry_extent, icb_log_block_num, parent):
      icb_log_block_num - The ICB logical block number.
      parent - The parent of the UDF File Entry.
     Returns:
-     A UDF File Entry object corresponding to the on-disk File Entry.
+     A UDFFileEntry object corresponding to the on-disk file entry, or
+     a UDFExtendedFileEntry (which is-a UDFFileEntry) for tag 266.
     """
     if all(v == 0 for v in bytearray(icbdata)):
         # We have seen ISOs in the wild (Windows 2008 Datacenter Enterprise
@@ -5875,12 +5851,14 @@ def parse_file_entry(icbdata, abs_file_entry_extent, icb_log_block_num, parent):
 
     desc_tag = UDFTag()
     desc_tag.parse(icbdata, icb_log_block_num)
-    if desc_tag.tag_ident != 261:
-        raise pycdlibexception.PyCdlibInvalidISO('UDF File Entry Tag identifier not 261')
+    if desc_tag.tag_ident == 261:
+        file_entry = UDFFileEntry()  # type: UDFFileEntry
+    elif desc_tag.tag_ident == 266:
+        file_entry = UDFExtendedFileEntry()
+    else:
+        raise pycdlibexception.PyCdlibInvalidISO('UDF File Entry Tag identifier not 261 or 266')
 
-    file_entry = UDFFileEntry()
     file_entry.parse(icbdata, abs_file_entry_extent, parent, desc_tag)
-
     return file_entry
 
 

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2662,6 +2662,183 @@ def test_new_udf_boot_descriptor_parsed():
     assert(len(iso2.udf_boots) == 1)
     iso2.close()
 
+def test_new_udf_creation_time_forces_efe_round_trip():
+    # Regression test for https://github.com/clalancette/pycdlib/issues/94.
+    # When the user supplies creation_time on add_directory/add_file for a
+    # UDF path, pycdlib must emit an Extended File Entry (tag 266) for that
+    # entry, since regular File Entries (tag 261) have no on-disk slot for
+    # creation_time.  Round-trip the resulting ISO and verify the
+    # creation_time, the EFE on-disk format, and that an unstamped child
+    # mirrors its EFE parent.
+    iso = pycdlib.PyCdlib()
+    iso.new(udf='2.60')
+    # An explicit creation_time forces EFE for /dir1.
+    creation_secs = 1234567890.0
+    iso.add_directory('/DIR1', udf_path='/dir1', creation_time=creation_secs)
+    # No creation_time on this child -- it must mirror the EFE parent.
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1', udf_path='/dir1/foo')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(io.BytesIO(out.getvalue()))
+
+    # The root was created without creation_time, parent=None, so it
+    # should still be a regular File Entry.
+    assert(iso2.udf_root is not None)
+    assert(type(iso2.udf_root) is pycdlib.udf.UDFFileEntry)
+    assert(iso2.udf_root.desc_tag.tag_ident == 261)
+
+    sub = iso2._find_udf_record(b'/dir1')[1]
+    assert(isinstance(sub, pycdlib.udf.UDFExtendedFileEntry))
+    assert(sub.desc_tag.tag_ident == 266)
+    # creation_time round-tripped (granularity is whole seconds).
+    assert(sub.creation_time.year == 2009)
+    assert(sub.creation_time.month == 2)
+    assert(sub.creation_time.day == 13)
+
+    foo = iso2._find_udf_record(b'/dir1/foo')[1]
+    # Mirroring: parent /dir1 is EFE, so /dir1/foo is EFE too even though
+    # the caller didn't supply a creation_time for it.
+    assert(isinstance(foo, pycdlib.udf.UDFExtendedFileEntry))
+    assert(foo.desc_tag.tag_ident == 266)
+
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, udf_path='/dir1/foo')
+    assert(buf.getvalue() == b'foo\n')
+
+    iso2.close()
+
+def test_new_udf_no_creation_time_keeps_fe():
+    # Sibling test: if no creation_time is supplied, every UDF entry stays
+    # in the regular File Entry format (tag 261), matching the parent.
+    iso = pycdlib.PyCdlib()
+    iso.new(udf='2.60')
+    iso.add_directory('/DIR1', udf_path='/dir1')
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1', udf_path='/foo')
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(io.BytesIO(out.getvalue()))
+    assert(type(iso2.udf_root) is pycdlib.udf.UDFFileEntry)
+    sub = iso2._find_udf_record(b'/dir1')[1]
+    assert(type(sub) is pycdlib.udf.UDFFileEntry)
+    foo = iso2._find_udf_record(b'/foo')[1]
+    assert(type(foo) is pycdlib.udf.UDFFileEntry)
+    iso2.close()
+
+def test_new_creation_time_no_compatible_storage_errors():
+    # creation_time has nowhere to live on plain ISO9660 / Joliet (the DR
+    # has no creation-time field), so passing it without RR or UDF raises.
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+        iso.add_fp(io.BytesIO(b'x'), 1, '/X.;1', creation_time=0.0)
+    assert('creation_time' in str(excinfo.value))
+    iso.close()
+
+def test_new_rock_ridge_creation_time_round_trip():
+    # On a Rock Ridge ISO, creation_time should land in the TF record's
+    # CREATION timestamp (bit 0).  Verify by re-opening and inspecting
+    # the parsed RRTFRecord.
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.09')
+    creation_secs = 1234567890.0
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1', rr_name='foo',
+               creation_time=creation_secs)
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(io.BytesIO(out.getvalue()))
+    rec = iso2.get_record(rr_path='/foo')
+    assert(rec.rock_ridge is not None)
+    tf = rec.rock_ridge.dr_entries.tf_record
+    if tf is None:
+        tf = rec.rock_ridge.ce_entries.tf_record
+    assert(tf is not None)
+    assert(tf.creation_time is not None)
+    assert(tf.creation_time.years_since_1900 == 109)  # 2009
+    assert(tf.creation_time.month == 2)
+    assert(tf.creation_time.day_of_month == 13)
+    iso2.close()
+
+def test_new_add_symlink_creation_time_forces_efe():
+    # add_symlink with creation_time on a UDF symlink path forces the
+    # EFE format for the symlink's UDF File Entry.
+    iso = pycdlib.PyCdlib()
+    iso.new(udf='2.60')
+    iso.add_symlink(udf_symlink_path='/lnk', udf_target='target',
+                    creation_time=1234567890.0)
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(io.BytesIO(out.getvalue()))
+    rec = iso2._find_udf_record(b'/lnk')[1]
+    assert(isinstance(rec, pycdlib.udf.UDFExtendedFileEntry))
+    assert(rec.creation_time.year == 2009)
+    iso2.close()
+
+def test_new_add_hard_link_creation_time_round_trip_rr():
+    # Rock Ridge hard links get their own DR (and own TF record) per link,
+    # so creation_time on the new link round-trips cleanly without
+    # disturbing the original DR.
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.09')
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1', rr_name='foo')
+    iso.add_hard_link(iso_old_path='/FOO.;1', iso_new_path='/FOO2.;1',
+                      rr_name='foo2', creation_time=1234567890.0)
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(io.BytesIO(out.getvalue()))
+    rec = iso2.get_record(rr_path='/foo2')
+    tf = rec.rock_ridge.dr_entries.tf_record
+    if tf is None:
+        tf = rec.rock_ridge.ce_entries.tf_record
+    assert(tf is not None)
+    assert(tf.creation_time is not None)
+    assert(tf.creation_time.years_since_1900 == 109)
+    # The original link's DR keeps its default flags (no creation_time).
+    rec_orig = iso2.get_record(rr_path='/foo')
+    tf_orig = rec_orig.rock_ridge.dr_entries.tf_record
+    if tf_orig is None:
+        tf_orig = rec_orig.rock_ridge.ce_entries.tf_record
+    assert(tf_orig is not None)
+    assert(tf_orig.creation_time is None)
+    iso2.close()
+
+def test_new_add_hard_link_creation_time_udf_rejected():
+    # UDF hard links share a single File Entry in pycdlib, so a per-link
+    # creation_time can't be honored -- we must reject it.
+    iso = pycdlib.PyCdlib()
+    iso.new(udf='2.60')
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1', udf_path='/foo')
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+        iso.add_hard_link(udf_old_path='/foo', udf_new_path='/foo2',
+                          creation_time=0.0)
+    assert('UDF hard links' in str(excinfo.value))
+    iso.close()
+
+def test_new_add_directory_creation_time_no_storage_errors():
+    # creation_time on add_directory must error if neither RR nor UDF can
+    # store it.
+    iso = pycdlib.PyCdlib()
+    iso.new(joliet=3)
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+        iso.add_directory(joliet_path='/dir1', creation_time=0.0)
+    assert('creation_time' in str(excinfo.value))
+    iso.close()
+
 def test_new_walk_with_non_utf8_directory_name():
     # Regression test for https://github.com/clalancette/pycdlib/issues/109.
     # The 1.15.0 walk encoding work decoded the file/directory names that

--- a/tests/unit/test_rockridge.py
+++ b/tests/unit/test_rockridge.py
@@ -888,6 +888,25 @@ def test_rrtfrecord_record_not_initialized():
 def test_rrtfrecord_length_use_vol_desc_dates():
     assert(pycdlib.rockridge.RRTFRecord.length(0x81) == 0x16)
 
+def test_rrtfrecord_new_creation_seconds_forces_creation_bit():
+    # Passing creation_seconds adds the creation_time bit (0x01) on top of
+    # whatever flags were requested, and the field is populated from the
+    # creation_seconds value rather than from date_seconds.
+    tf = pycdlib.rockridge.RRTFRecord()
+    tf.new(pycdlib.rockridge.TF_FLAGS, 0.0, creation_seconds=1234567890.0)
+    assert(tf.time_flags & 0x01)
+    assert(tf.creation_time is not None)
+    assert(tf.creation_time.years_since_1900 == 109)
+    assert(tf.creation_time.month == 2)
+    assert(tf.creation_time.day_of_month == 13)
+
+def test_rrtfrecord_new_no_creation_seconds_keeps_flags():
+    tf = pycdlib.rockridge.RRTFRecord()
+    tf.new(pycdlib.rockridge.TF_FLAGS, 0.0)
+    # No creation_seconds -> creation_time bit stays off, no field set.
+    assert(not (tf.time_flags & 0x01))
+    assert(tf.creation_time is None)
+
 # SF record
 def test_rrsfrecord_parse_double_initialized():
     sf = pycdlib.rockridge.RRSFRecord()

--- a/tests/unit/test_udf.py
+++ b/tests/unit/test_udf.py
@@ -2669,55 +2669,128 @@ def test_part_integrity_new():
     part.new('dir')
     assert(part.desc_tag.tag_ident == 265)
 
-# Extended File
-def test_extended_file_parse_initialized_twice():
+# Extended File Entry (tag 266; subclass of UDFFileEntry)
+def _build_efe_body(file_type=4, checkpoint=1, record_format=0,
+                    record_display_attrs=0, record_len=0):
+    icb_tag = struct.pack('<LHHHBB6sH', 0, 4, 0, 0, 0, file_type, b'\x00' * 6, 0)
+    ts = b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00'
+    return struct.pack(pycdlib.udf.UDFExtendedFileEntry.FMT,
+                       b'\x00' * 16, icb_tag, 0, 0, 0, 0,
+                       record_format, record_display_attrs, record_len,
+                       0, 0, 0, ts, ts, ts, ts, checkpoint,
+                       b'\x00' * 4, b'\x00' * 16, b'\x00' * 16,
+                       b'\x00' * 32, 0, 0, 0)
+
+def test_extended_file_entry_is_udf_file_entry_subclass():
+    assert(issubclass(pycdlib.udf.UDFExtendedFileEntry, pycdlib.udf.UDFFileEntry))
+
+def test_extended_file_entry_parse_initialized_twice():
     tag = pycdlib.udf.UDFTag()
     tag.new(0, 0)
-
     ef = pycdlib.udf.UDFExtendedFileEntry()
-    ef.parse(b'\x00'*16 + b'\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x00\x00' + b'\x00'*4 + b'\x00'*16 + b'\x00'*16 + b'\x00'*32 + b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0, tag)
+    ef.parse(_build_efe_body(), 0, None, tag)
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInternalError) as excinfo:
-        ef.parse(b'\x00'*16 + b'\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x00\x00' + b'\x00'*4 + b'\x00'*16 + b'\x00'*16 + b'\x00'*32 + b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0, tag)
+        ef.parse(_build_efe_body(), 0, None, tag)
     assert(str(excinfo.value) == 'UDF Extended File Entry already initialized')
 
-def test_extended_file_parse():
+def test_extended_file_entry_parse():
     tag = pycdlib.udf.UDFTag()
-    tag.new(0, 0)
-
+    tag.new(266, 0)
     ef = pycdlib.udf.UDFExtendedFileEntry()
-    ef.parse(b'\x00'*16 + b'\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x00\x00' + b'\x00'*4 + b'\x00'*16 + b'\x00'*16 + b'\x00'*32 + b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 0, tag)
-    assert(ef.desc_tag.tag_ident == 0)
+    ef.parse(_build_efe_body(file_type=4), 0, None, tag)
+    assert(isinstance(ef, pycdlib.udf.UDFFileEntry))
+    assert(ef.desc_tag.tag_ident == 266)
+    assert(ef.is_dir())
+    assert(ef.creation_time is not None)
+    assert(ef.stream_icb is not None)
 
-def test_extended_file_record_not_initialized():
+def test_extended_file_entry_parse_bad_record_format():
+    tag = pycdlib.udf.UDFTag()
+    tag.new(266, 0)
+    ef = pycdlib.udf.UDFExtendedFileEntry()
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
+        ef.parse(_build_efe_body(record_format=1), 0, None, tag)
+    assert(str(excinfo.value) == 'File Entry record format is not 0')
+
+def test_extended_file_entry_parse_bad_record_display_attrs():
+    tag = pycdlib.udf.UDFTag()
+    tag.new(266, 0)
+    ef = pycdlib.udf.UDFExtendedFileEntry()
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
+        ef.parse(_build_efe_body(record_display_attrs=1), 0, None, tag)
+    assert(str(excinfo.value) == 'File Entry record display attributes is not 0')
+
+def test_extended_file_entry_parse_bad_record_len():
+    tag = pycdlib.udf.UDFTag()
+    tag.new(266, 0)
+    ef = pycdlib.udf.UDFExtendedFileEntry()
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
+        ef.parse(_build_efe_body(record_len=1), 0, None, tag)
+    assert(str(excinfo.value) == 'File Entry record length is not 0')
+
+def test_extended_file_entry_parse_bad_checkpoint():
+    tag = pycdlib.udf.UDFTag()
+    tag.new(266, 0)
+    ef = pycdlib.udf.UDFExtendedFileEntry()
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
+        ef.parse(_build_efe_body(checkpoint=0), 0, None, tag)
+    assert(str(excinfo.value) == 'Only DVD Read-only disks supported')
+
+def test_extended_file_entry_record_not_initialized():
     ef = pycdlib.udf.UDFExtendedFileEntry()
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInternalError) as excinfo:
         ef.record()
     assert(str(excinfo.value) == 'UDF Extended File Entry not initialized')
 
-def test_extended_file_record():
+def test_extended_file_entry_record_round_trip():
+    # Round-trip the body bytes: parse, then record, should match the input
+    # (modulo the 16-byte tag, which is regenerated by desc_tag.record).
+    body = _build_efe_body()
     tag = pycdlib.udf.UDFTag()
-    tag.new(0, 0)
-
+    tag.new(266, 0)
     ef = pycdlib.udf.UDFExtendedFileEntry()
-    ef.parse(b'\x00'*16 + b'\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00' + b'\x00\x00\x00\x00' + b'\x00'*4 + b'\x00'*16 + b'\x00'*16 + b'\x00'*32 + b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00' + b'\x00\x00\x00\x00\x00\x00\x00\x00', 0, tag)
-    assert(ef.record() == b'\x00\x00\x02\x00\xf1\x00\x00\x00\x52\xcd\xd0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+    ef.parse(body, 0, None, tag)
+    out = ef.record()
+    assert(out[16:] == body[16:])
 
-def test_extended_file_new_initialized_twice():
+def test_extended_file_entry_new_creation_seconds():
     ef = pycdlib.udf.UDFExtendedFileEntry()
-    ef.new('dir', 0, 2048)
-    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInternalError) as excinfo:
-        ef.new('dir', 0, 2048)
-    assert(str(excinfo.value) == 'UDF Extended File Entry already initialized')
-
-def test_extended_file_new_dir():
-    ef = pycdlib.udf.UDFExtendedFileEntry()
-    ef.new('dir', 0, 2048)
+    ef.new(0, 'dir', None, 2048, creation_seconds=1234567890.0)
     assert(ef.desc_tag.tag_ident == 266)
+    assert(ef.creation_time.year == 2009)
+    assert(ef.creation_time.month == 2)
+    assert(ef.creation_time.day == 13)
 
-def test_extended_file_new_file():
+def test_extended_file_entry_new_default_creation_time():
     ef = pycdlib.udf.UDFExtendedFileEntry()
-    ef.new('file', 5, 2048)
+    ef.new(0, 'dir', None, 2048)
+    # When creation_seconds isn't supplied, EFE.new uses the current time.
     assert(ef.desc_tag.tag_ident == 266)
+    assert(ef.creation_time is not None)
+
+def test_extended_file_entry_inherits_runtime_interface():
+    # Sanity: methods inherited from UDFFileEntry must work on EFE instances.
+    tag = pycdlib.udf.UDFTag()
+    tag.new(266, 0)
+    ef = pycdlib.udf.UDFExtendedFileEntry()
+    ef.parse(_build_efe_body(file_type=5), 0, None, tag)
+    assert(ef.is_file())
+    assert(not ef.is_dir())
+    assert(not ef.is_dot())
+    assert(not ef.is_dotdot())
+    assert(ef.file_identifier() == b'/')
+    assert(ef.get_data_length() == 0)
+
+# parse_file_entry tag dispatch
+def test_parse_file_entry_unknown_tag():
+    # tag 100 is neither 261 (FE) nor 266 (EFE).
+    tag = pycdlib.udf.UDFTag()
+    tag.new(100, 0)
+    body = b'\x00' * 200
+    icbdata = tag.record(body) + body
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
+        pycdlib.udf.parse_file_entry(icbdata, 0, 0, None)
+    assert(str(excinfo.value) == 'UDF File Entry Tag identifier not 261 or 266')
 
 # parse_allocation_descriptors
 def test_parse_allocation_descriptors_long():


### PR DESCRIPTION
This wires up the UDF Extended File Entries (EFE) so they can actually be used.  They are now parsed properly, round-tripped, and can be set at entry "new" time with a "creation_time" parameter.  They do have a couple of limitations:

1.  You cannot set the root entry to EFE currently.  This is easy to add, just not implemented yet.
2.  You cannot set named streams on an EFE currently.  This is trickier to support since a named stream is a UDF/EFE concept only and doesn't map nicely to the other entry types.

Fixes #94 

(for the most part)