### PR TITLE
Fix RR double-parse problem.

### DIFF
--- a/pycdlib/rockridge.py
+++ b/pycdlib/rockridge.py
@@ -2694,13 +2694,30 @@ class RockRidge:
         # above as a hint, and allow for some wiggle room.
 
         if px_record_length == 44 or sf_record_length == 21 or has_es_record or er_id == EXT_ID_112:
-            self.rr_version = '1.12'
+            this_call_version = '1.12'
+        elif sf_record_length == 12:
+            this_call_version = '1.10'
         else:
-            # Not 1.12, so either 1.09 or 1.10.
-            if sf_record_length == 12:
-                self.rr_version = '1.10'
-            else:
-                self.rr_version = '1.09'
+            this_call_version = '1.09'
+
+        if continuation:
+            # parse() runs once for the inline DR area (continuation=False)
+            # and a second time for the CE block (continuation=True).
+            # The 1.09 / 1.10 / 1.12 signals can appear on either side --
+            # e.g. an ISO whose 44-byte PX is inline but whose CE block
+            # carries only NM/SL records would, on the second call, see
+            # no 1.12 evidence and (without this guard) demote
+            # rr_version back to '1.09'.  That demotion silently
+            # downsizes the PX record on write, which produces an ISO
+            # with a dr_len longer than the bytes actually emitted (the
+            # tail then bleeds into the next record on re-parse).  Only
+            # let the continuation pass *upgrade* rr_version, never
+            # downgrade it.
+            ranks = {'1.09': 0, '1.10': 1, '1.12': 2}
+            if ranks[this_call_version] > ranks[self.rr_version]:
+                self.rr_version = this_call_version
+        else:
+            self.rr_version = this_call_version
 
         namelist = [nm.posix_name for nm in self.dr_entries.nm_records]
         namelist.extend([nm.posix_name for nm in self.ce_entries.nm_records])

--- a/tests/unit/test_rockridge.py
+++ b/tests/unit/test_rockridge.py
@@ -1535,6 +1535,66 @@ def test_rr_update_ce_block_not_initialized():
         rr.update_ce_block(None)
     assert(str(excinfo.value) == 'Rock Ridge extension not initialized')
 
+def test_rr_parse_continuation_does_not_downgrade_version():
+    # Regression test: RockRidge.parse() runs once for the inline DR area
+    # and a second time (with continuation=True) for the CE block.  Each
+    # call recomputes its own rr_version from the records it sees in
+    # that buffer.  Before the fix, the second call would unconditionally
+    # overwrite self.rr_version, so an ISO whose 44-byte (RR 1.12) PX
+    # was inline but whose CE block carried only NM/SL/etc. would end
+    # up with rr_version demoted back to '1.09'.  On write, that
+    # produced a 36-byte PX (8 bytes shorter than the dr_len field
+    # claimed) and the next round-trip would fail with "Invalid RR
+    # version 0!" parsing the resulting 8 bytes of trailing slop.
+    def le_be(val):
+        return struct.pack('<L', val) + struct.pack('>L', val)
+
+    ts7 = b'\x00\x00\x01\x01\x01\x01\x00'  # valid 7-byte DirectoryRecordDate
+
+    # Inline RR: SP + RR + PX (44-byte / 1.12 form) + TF + CE.
+    sp = b'SP\x07\x01\xbe\xef\x00'
+    rr_rec = b'RR\x05\x01\x81'
+    px_1_12 = (b'PX\x2c\x01' + le_be(0o100644) + le_be(1)
+               + le_be(0) + le_be(0) + le_be(0))
+    tf = b'TF\x1a\x01\x0e' + ts7 * 3
+    ce = b'CE\x1c\x01' + le_be(0) + le_be(0) + le_be(0)
+    inline = sp + rr_rec + px_1_12 + tf + ce
+    assert(len(inline) == 110)  # sanity
+
+    # Continuation block: a single NM record.  No PX, no SF, no ES, no
+    # ER -- nothing that signals 1.12.
+    nm = b'NM\x06\x01\x00X'
+
+    rr = pycdlib.rockridge.RockRidge()
+    rr.parse(inline, True, 0, False, b'.')
+    assert(rr.rr_version == '1.12')
+
+    rr.parse(nm, False, 0, True, b'.')
+    assert(rr.rr_version == '1.12')
+
+def test_rr_parse_continuation_can_upgrade_version():
+    # Inverse of the above: if the inline area has no 1.12 signals but
+    # the continuation does, rr_version should escalate to '1.12'.
+    def le_be(val):
+        return struct.pack('<L', val) + struct.pack('>L', val)
+
+    ts7 = b'\x00\x00\x01\x01\x01\x01\x00'
+
+    # Inline: just SP and CE (no PX), so rr_version starts at '1.09'.
+    inline = (b'SP\x07\x01\xbe\xef\x00'
+              + b'CE\x1c\x01' + le_be(0) + le_be(0) + le_be(0))
+
+    # Continuation carries a 44-byte PX (1.12 signal).
+    px_1_12 = (b'PX\x2c\x01' + le_be(0o100644) + le_be(1)
+               + le_be(0) + le_be(0) + le_be(0))
+
+    rr = pycdlib.rockridge.RockRidge()
+    rr.parse(inline, True, 0, False, b'.')
+    assert(rr.rr_version == '1.09')
+
+    rr.parse(px_1_12, False, 0, True, b'.')
+    assert(rr.rr_version == '1.12')
+
 # RockRidgeContinuationBlock and RockRidgeContinuationEntry
 def test_rrcontentry_track_into_empty():
     rr = pycdlib.rockridge.RockRidgeContinuationBlock(24, 2048)


### PR DESCRIPTION
When trying to round-trip certain RockRidge ISOs, they would fail with invalid RR size.  That's because the parsing would happen twice for a DR with a CE, and the latter one would overwrite the original one.

The fix is to only ever escalate the version, not reset it.