### PR TITLE
Fix files larger than 8.6 GB.

### DIFF
--- a/pycdlib/dr.py
+++ b/pycdlib/dr.py
@@ -792,6 +792,11 @@ class DirectoryRecord:
                     if not allow_duplicate:
                         raise pycdlibexception.PyCdlibInvalidInput('Failed adding duplicate name to parent')
 
+                    # For multi-extent files (3+ chunks), there can already be
+                    # multiple contiguous duplicates here.  Walk forward to the
+                    # last one so we link onto the tail of the existing chain.
+                    while index + 1 < len(self.children) and self.children[index + 1].file_ident == child.file_ident:
+                        index += 1
                     self.children[index].data_continuation = child
                     self.children[index].file_flags |= (1 << self.FILE_FLAG_MULTI_EXTENT_BIT)
                     index += 1

--- a/tests/unit/test_dr.py
+++ b/tests/unit/test_dr.py
@@ -448,3 +448,48 @@ def test_dr_file_too_big():
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
         dr.new_file(pvd, 2**32, b'', None, 1, '', b'', False, 0, 0)
     assert(str(excinfo.value) == 'Maximum supported file length is 2^32-1')
+
+def test_dr_add_child_multi_extent_chain():
+    # Regression test for issue #134.  Files larger than ~8.6 GiB are split
+    # into 3+ multi-extent chunks (max 0xfffff800 bytes per chunk).  All
+    # chunks share the same file_ident, so bisect_left returns the leftmost
+    # duplicate when each new chunk is added.  The previous logic always
+    # linked data_continuation onto self.children[index] (the leftmost
+    # duplicate), which (a) overwrote the prior continuation pointer once
+    # there were 3+ chunks and (b) inserted new chunks between the head and
+    # earlier chunks, scrambling the on-disk order.  The fix walks forward
+    # to the last existing duplicate before linking.
+    pvd = pycdlib.headervd.pvd_factory(b'', b'', 0, 0, 0, b'', b'', b'', b'', b'', b'', b'', 0.0, b'', False)
+    root_dr = pycdlib.dr.DirectoryRecord()
+    root_dr.new_root(pvd, 1, 2048, time.time())
+
+    chunks = []
+    for i in range(6):
+        chunk = pycdlib.dr.DirectoryRecord()
+        chunk.new_file(pvd, 1024, b'BIG.TAR;1', root_dr, 1, '', b'', False, 0,
+                       time.time())
+        chunks.append(chunk)
+
+    # The first chunk uses add_child (raises on duplicate); subsequent chunks
+    # need allow_duplicate=True, mirroring the parser's behavior for very
+    # large files.
+    root_dr.add_child(chunks[0], 2048)
+    for chunk in chunks[1:]:
+        root_dr.add_child(chunk, 2048, True)
+
+    # Children must remain in insertion order.
+    big_children = [c for c in root_dr.children if c.file_ident == b'BIG.TAR;1']
+    assert(big_children == chunks)
+
+    # data_continuation must form a single chain in insertion order.
+    walked = []
+    cur = chunks[0]
+    while cur is not None:
+        walked.append(cur)
+        cur = cur.data_continuation
+    assert(walked == chunks)
+
+    # The multi-extent bit is set on every chunk except the last.
+    for chunk in chunks[:-1]:
+        assert(chunk.file_flags & (1 << pycdlib.dr.DirectoryRecord.FILE_FLAG_MULTI_EXTENT_BIT))
+    assert(not (chunks[-1].file_flags & (1 << pycdlib.dr.DirectoryRecord.FILE_FLAG_MULTI_EXTENT_BIT)))


### PR DESCRIPTION
These are split into more than 3 multi-extent chunks. But the logic always linked data_continuation into the leftmost duplicate, which overwrite the prior
continuation pointer, and also inserted new chunks in the wrong order, scrambling the on-disk order.

FIx it by walking forward to the last duplicate before linking.

Fixes #134