### PR TITLE
Fix UDF large-file support.

### DIFF
--- a/pycdlib/dr.py
+++ b/pycdlib/dr.py
@@ -163,8 +163,9 @@ class DirectoryRecord:
                  'rr_children', 'inode', '_printable_name', 'date',
                  'index_in_parent', 'dr_len', 'xattr_len', 'file_flags',
                  'file_unit_size', 'interleave_gap_size', 'len_fi', 'isdir',
-                 'orig_extent_loc', 'data_length', 'seqnum', 'is_root',
-                 'parent', 'rock_ridge', 'xa_record', 'file_ident', '_sort_key')
+                 'orig_extent_loc', 'data_length', 'data_extent_offset',
+                 'seqnum', 'is_root', 'parent', 'rock_ridge', 'xa_record',
+                 'file_ident', '_sort_key')
 
     FILE_FLAG_EXISTENCE_BIT = 0
     FILE_FLAG_DIRECTORY_BIT = 1
@@ -184,6 +185,13 @@ class DirectoryRecord:
         self.extents_to_here = 1
         self.offset_to_here = 0
         self.data_continuation = None  # type: Optional[DirectoryRecord]
+        # data_extent_offset is the offset (in logical blocks) of this record's
+        # data slice from the start of its inode's allocated extent run.  It is
+        # always 0 except for the second-and-later chunks of an ISO9660
+        # multi-extent file that shares a single Inode with its sibling chunks
+        # (the UDF Bridge layout produced by _add_fp for files larger than
+        # 0xfffff800 bytes).
+        self.data_extent_offset = 0
         self.children = []  # type: List[DirectoryRecord]
         self.rr_children = []  # type: List[DirectoryRecord]
         self.index_in_parent = -1

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -1154,9 +1154,10 @@ class PyCdlib:
                         # The end of the file is beyond the size of the ISO.
                         # Since this can't be true, truncate the file size.
                         if new_record.inode is not None:
-                            new_record.inode.data_length = iso_file_length - extent_to_use * self.logical_block_size
+                            truncated_length = iso_file_length - extent_to_use * self.logical_block_size
+                            new_record.inode.data_length = truncated_length
                             for rec, is_pvd in new_record.inode.linked_records:
-                                rec.set_data_length(new_end)
+                                rec.set_data_length(truncated_length)
                     else:
                         # The new end is still within the file size, but the PVD
                         # size is wrong.  Set the lastbyte appropriately, which
@@ -1518,8 +1519,15 @@ class PyCdlib:
 
         ino.set_extent_location(current_extent)
         for rec, pvd_unused in ino.linked_records:
-            rec.set_data_location(current_extent,
-                                  current_extent - part_start)
+            # ISO9660 multi-extent chunks share a single Inode; each
+            # DirectoryRecord for a chunk carries the block offset of its
+            # slice within the inode's allocated extent run.  UDF File
+            # Entries leave data_extent_offset at 0 -- their
+            # set_data_location walks alloc_descs consecutively from the
+            # inode's start.
+            rec_offset = getattr(rec, 'data_extent_offset', 0)
+            rec.set_data_location(current_extent + rec_offset,
+                                  current_extent + rec_offset - part_start)
 
         current_extent += utils.ceiling_div(ino.get_data_length(),
                                             self.logical_block_size)
@@ -2220,6 +2228,16 @@ class PyCdlib:
                         else:
                             if abs_file_data_extent in extent_to_inode:
                                 ino = extent_to_inode[abs_file_data_extent]
+                                # In a UDF Bridge ISO, the UDF File Entry
+                                # describes the whole file in one Inode while
+                                # the ISO9660 side splits it into multi-extent
+                                # chunks.  When pycdlib parses the ISO9660
+                                # chunks first, only chunk 1's length lives in
+                                # the deduplicated inode.  Extend that inode
+                                # to UDF's full info_len so a UDF read returns
+                                # the complete file.
+                                if next_entry.get_data_length() > ino.data_length:
+                                    ino.data_length = next_entry.get_data_length()
                             else:
                                 ino = inode.Inode()
                                 ino.parse(abs_file_data_extent,
@@ -2554,13 +2572,25 @@ class PyCdlib:
         if found_record.inode is None:
             raise pycdlibexception.PyCdlibInvalidInput('Cannot write out a file without data')
 
-        while found_record.get_data_length() > 0:
-            with inode.InodeOpenData(found_record.inode, self.logical_block_size) as (data_fp, data_len):
-                # Copy the data into the output file descriptor.  If a boot info
-                # table is present, overlay the table over bytes 8-64 of the
-                # file.  Note that we never return more bytes than the length
-                # of the file, so the boot info table may get truncated.
-                if found_record.inode.boot_info_table is not None:
+        # Walk the multi-extent data_continuation chain.  Each chunk reads
+        # rec.data_length bytes starting at its slice within the inode --
+        # this covers both the parse-mode case (each chunk has its own
+        # per-chunk Inode at offset 0) and the _add_fp case (all chunks
+        # share a single Inode with data_extent_offset describing each
+        # chunk's block offset into the run).
+        first_chunk = True
+        while found_record.inode is not None and found_record.data_length > 0:
+            with inode.InodeOpenData(found_record.inode, self.logical_block_size) as (data_fp, _):
+                if found_record.data_extent_offset:
+                    data_fp.seek(found_record.data_extent_offset * self.logical_block_size,
+                                 os.SEEK_CUR)
+                data_len = found_record.data_length
+                # Copy the data into the output file descriptor.  If a boot
+                # info table is present, overlay the table over bytes 8-64
+                # of the first chunk.  Note that we never return more bytes
+                # than the length of the chunk, so the boot info table may
+                # get truncated.
+                if first_chunk and found_record.inode.boot_info_table is not None:
                     header_len = min(data_len, 8)
                     outfp.write(data_fp.read(header_len))
                     data_len -= header_len
@@ -2575,6 +2605,7 @@ class PyCdlib:
                 else:
                     utils.copy_data(data_len, blocksize, data_fp, outfp)
 
+            first_chunk = False
             if found_record.data_continuation is not None:
                 found_record = found_record.data_continuation
             else:
@@ -3124,8 +3155,9 @@ class PyCdlib:
             self._needs_reshuffle = True
 
     def _add_hard_link_to_inode(self, data_ino, length, file_mode,
-                                boot_catalog_old, creation_time, **kwargs):
-        # type: (Optional[inode.Inode], int, int, bool, Optional[float], Optional[str]) -> int
+                                boot_catalog_old, creation_time,
+                                data_extent_offset_blocks=0, **kwargs):
+        # type: (Optional[inode.Inode], int, int, bool, Optional[float], int, Optional[str]) -> int
         """
         Add a hard link to the ISO.  Hard links are alternate names for the
         same file contents that don't take up any additional space on the ISO.
@@ -3207,6 +3239,7 @@ class PyCdlib:
             new_rec.new_file(vd, length, new_name, new_parent,
                              vd.sequence_number(), rr, rr_name, xa, file_mode,
                              time.time(), creation_time)
+            new_rec.data_extent_offset = data_extent_offset_blocks
 
             num_bytes_to_add += self._add_child_to_dr(new_rec)
             num_bytes_to_add += self._update_rr_ce_entry(new_rec)
@@ -3315,47 +3348,57 @@ class PyCdlib:
         if length > (2**32) - 1 and self.interchange_level < 3:
             raise pycdlibexception.PyCdlibInvalidInput('File sizes for interchange level < 3 must be less than 4GiB')
 
-        left = length
-        offset = 0
-        done = False
-        num_bytes_to_add = 0
-        while not done:
-            # The maximum length we allow in one directory record is 0xfffff800
-            # (this is taken from xorriso, though I don't really know why).
-            thislen = min(left, 0xfffff800)
+        # The maximum length representable in a single ISO9660 directory
+        # record (taken from xorriso).  Files larger than this are split
+        # across multiple multi-extent directory records on the ISO9660 /
+        # Joliet side, while UDF represents the same file as a single File
+        # Entry whose allocation descriptors cover the full extent run.
+        # Both views reference the same physical extents on disc -- the
+        # "UDF Bridge" layout described in ECMA-167.
+        single_chunk_length = 0xfffff800
 
-            ino = None
-            if fp is not None:
-                ino = inode.Inode()
-                ino.new(thislen, fp, manage_fp, offset)
+        # Single Inode covering the whole file.  Every view (ISO9660 chunks,
+        # Joliet chunks, and UDF) links to this same Inode.  Each ISO9660 /
+        # Joliet chunk records its block offset within the inode's extent
+        # run via DirectoryRecord.data_extent_offset; the UDF File Entry's
+        # alloc_descs walk consecutively from the inode's start.
+        ino = None
+        if fp is not None:
+            ino = inode.Inode()
+            ino.new(length, fp, manage_fp, 0)
 
-            num_bytes_to_add += thislen
-            if iso_path:
-                num_bytes_to_add += self._add_hard_link_to_inode(ino, thislen,
-                                                                 fmode,
-                                                                 eltorito_catalog,
-                                                                 creation_time,
-                                                                 iso_new_path=iso_path,
-                                                                 rr_name=rr_name)
+        num_bytes_to_add = length
 
-            if joliet_path:
-                # If this is a Joliet ISO, then we can re-use add_hard_link to do
-                # most of the work.
-                num_bytes_to_add += self._add_hard_link_to_inode(ino, thislen,
-                                                                 fmode,
-                                                                 eltorito_catalog,
-                                                                 creation_time,
-                                                                 joliet_new_path=joliet_path)
+        if iso_path or joliet_path:
+            left = length
+            chunk_offset_blocks = 0
+            done = False
+            while not done:
+                thislen = min(left, single_chunk_length)
 
-            # This goes after the hard link so we only track the new Inode if
-            # everything above succeeds
-            if ino is not None:
-                self.inodes.append(ino)
+                if iso_path:
+                    num_bytes_to_add += self._add_hard_link_to_inode(ino, thislen,
+                                                                     fmode,
+                                                                     eltorito_catalog,
+                                                                     creation_time,
+                                                                     iso_new_path=iso_path,
+                                                                     rr_name=rr_name,
+                                                                     data_extent_offset_blocks=chunk_offset_blocks)
 
-            left -= thislen
-            offset += thislen
-            if left == 0:
-                done = True
+                if joliet_path:
+                    # If this is a Joliet ISO, then we can re-use add_hard_link to do
+                    # most of the work.
+                    num_bytes_to_add += self._add_hard_link_to_inode(ino, thislen,
+                                                                     fmode,
+                                                                     eltorito_catalog,
+                                                                     creation_time,
+                                                                     joliet_new_path=joliet_path,
+                                                                     data_extent_offset_blocks=chunk_offset_blocks)
+
+                left -= thislen
+                chunk_offset_blocks += thislen // self.logical_block_size
+                if left == 0:
+                    done = True
 
         if udf_path:
             num_bytes_to_add += self._add_hard_link_to_inode(ino, length,
@@ -3363,6 +3406,11 @@ class PyCdlib:
                                                              eltorito_catalog,
                                                              creation_time,
                                                              udf_new_path=udf_path)
+
+        # Track the Inode after all linked records have been created so that
+        # a failure in one of the hard-link calls leaves no orphan behind.
+        if ino is not None:
+            self.inodes.append(ino)
 
         return num_bytes_to_add
 

--- a/tests/integration/test_common.py
+++ b/tests/integration/test_common.py
@@ -481,7 +481,10 @@ def internal_check_file(dirrecord, name, dr_len, loc, datalen, hidden, multi_ext
         assert(dirrecord.file_flags == 128)
     else:
         assert(dirrecord.file_flags == 0)
-    assert(dirrecord.get_data_length() == datalen)
+    # data_length is the per-chunk on-disc value; get_data_length() may report
+    # the shared inode's full-file length when this DR is one chunk of a
+    # multi-extent file added via _add_fp.
+    assert(dirrecord.data_length == datalen)
 
 def internal_generate_inorder_names(numdirs):
     tmp = []

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -4918,6 +4918,140 @@ def test_new_udf_very_large(tmpdir):
 
     iso.close()
 
+def test_new_udf_above_multi_extent_threshold(tmpdir):
+    # Regression test for issue #65: a UDF file larger than the ISO9660
+    # multi-extent boundary (0xfffff800 ~= 4 GiB) used to leave the UDF
+    # File Entry pointing at only the last fragment's inode while the
+    # earlier fragments became orphaned inodes.  Use a sparse input and
+    # verify the in-memory state without writing the (~4 GiB) ISO out.
+    indir = tmpdir.mkdir('udfabovemulti')
+    largefile = os.path.join(str(indir), 'foo')
+
+    SIZE = 0xfffff800 + 1
+    with open(largefile, 'wb') as outfp:
+        outfp.truncate(SIZE)
+
+    iso = pycdlib.PyCdlib()
+    iso.new(interchange_level=3, udf='2.60')
+    iso.add_file(largefile, udf_path='/foo')
+
+    fe = iso.udf_root.fi_descs[1].file_entry
+    assert(fe.info_len == SIZE)
+    assert(sum(ad.extent_length for ad in fe.alloc_descs) == SIZE)
+    assert(fe.inode is not None)
+    assert(fe.inode.data_length == SIZE)
+    assert(fe.inode.fp_offset == 0)
+    # Exactly one inode should be tracked: the full-file UDF inode.  Without
+    # the fix, the splitting loop would also leave an orphaned per-chunk
+    # inode behind.
+    assert(len(iso.inodes) == 1)
+    assert(iso.inodes[0] is fe.inode)
+    assert(len(fe.inode.linked_records) == 1)
+
+    iso.close()
+
+@pytest.mark.slow
+def test_new_udf_above_multi_extent_threshold_roundtrip(tmpdir):
+    # Round-trip companion to test_new_udf_above_multi_extent_threshold:
+    # write a >4 GiB UDF file to a real ISO and read it back to verify the
+    # data on either side of the multi-extent boundary survives intact.
+    indir = tmpdir.mkdir('udfabovemultirt')
+    largefile = os.path.join(str(indir), 'foo')
+    output_iso = os.path.join(str(indir), 'udfabovemulti.iso')
+    extracted = os.path.join(str(indir), 'extracted')
+
+    SIZE = 0xfffff800 + 4096
+    boundary = 0xfffff800
+    with open(largefile, 'wb') as outfp:
+        outfp.truncate(SIZE)
+        outfp.seek(0)
+        outfp.write(b'\xaa' * 16)
+        outfp.seek(boundary - 8)
+        outfp.write(b'\xbb' * 16)
+        outfp.seek(SIZE - 16)
+        outfp.write(b'\xcc' * 16)
+
+    iso = pycdlib.PyCdlib()
+    iso.new(interchange_level=3, udf='2.60')
+    iso.add_file(largefile, udf_path='/foo')
+    iso.write(output_iso)
+    iso.close()
+
+    newiso = pycdlib.PyCdlib()
+    newiso.open(output_iso)
+    newiso.get_file_from_iso(extracted, udf_path='/foo')
+    newiso.close()
+
+    assert(os.stat(extracted).st_size == SIZE)
+    with open(extracted, 'rb') as fp:
+        assert(fp.read(16) == b'\xaa' * 16)
+        fp.seek(boundary - 8)
+        assert(fp.read(16) == b'\xbb' * 16)
+        fp.seek(SIZE - 16)
+        assert(fp.read(16) == b'\xcc' * 16)
+
+@pytest.mark.slow
+def test_new_udf_bridge_above_multi_extent_threshold(tmpdir):
+    # UDF Bridge round-trip for a file larger than 0xfffff800 bytes.  Both
+    # the ISO9660 and UDF views must point at the same physical extents
+    # (single copy of the file data on disc, per ECMA-167) and both must
+    # extract identical content.
+    indir = tmpdir.mkdir('bridgeabovemultirt')
+    largefile = os.path.join(str(indir), 'foo')
+    output_iso = os.path.join(str(indir), 'bridge.iso')
+    extracted_iso = os.path.join(str(indir), 'extracted_iso')
+    extracted_udf = os.path.join(str(indir), 'extracted_udf')
+
+    SIZE = 0xfffff800 + 4096
+    boundary = 0xfffff800
+    with open(largefile, 'wb') as outfp:
+        outfp.truncate(SIZE)
+        outfp.seek(0)
+        outfp.write(b'\xaa' * 16)
+        outfp.seek(boundary - 8)
+        outfp.write(b'\xbb' * 16)
+        outfp.seek(SIZE - 16)
+        outfp.write(b'\xcc' * 16)
+
+    iso = pycdlib.PyCdlib()
+    iso.new(interchange_level=3, udf='2.60')
+    iso.add_file(largefile, '/FOO.;1', udf_path='/foo')
+
+    # Single shared inode across the ISO9660 multi-extent chunks and the UDF
+    # File Entry: confirm we don't have separate per-chunk inodes for the
+    # ISO9660 view.
+    file_inodes = [ino for ino in iso.inodes if ino.data_length > 0]
+    assert(len(file_inodes) == 1)
+    assert(file_inodes[0].data_length == SIZE)
+    # 2 ISO9660 multi-extent chunks + 1 UDF File Entry = 3 linked records.
+    assert(len(file_inodes[0].linked_records) == 3)
+
+    iso.write(output_iso)
+    iso.close()
+
+    # The on-disc file should contain a single copy of the data.  An
+    # over-budget bound: header/metadata extents + ceil(SIZE/2048) data
+    # extents + a small slack for trailing UDF anchors and padding.  If the
+    # data were duplicated, the size would balloon by roughly another SIZE.
+    iso_size = os.stat(output_iso).st_size
+    data_extents = (SIZE + 2047) // 2048
+    assert(iso_size < (data_extents + 4096) * 2048)
+
+    newiso = pycdlib.PyCdlib()
+    newiso.open(output_iso)
+    newiso.get_file_from_iso(extracted_iso, iso_path='/FOO.;1')
+    newiso.get_file_from_iso(extracted_udf, udf_path='/foo')
+    newiso.close()
+
+    for extracted in (extracted_iso, extracted_udf):
+        assert(os.stat(extracted).st_size == SIZE)
+        with open(extracted, 'rb') as fp:
+            assert(fp.read(16) == b'\xaa' * 16)
+            fp.seek(boundary - 8)
+            assert(fp.read(16) == b'\xbb' * 16)
+            fp.seek(SIZE - 16)
+            assert(fp.read(16) == b'\xcc' * 16)
+
 def test_new_lookup_after_rmdir():
     iso = pycdlib.PyCdlib()
     iso.new()


### PR DESCRIPTION
The problem was that UDF file entries for large files specify a single entry with the maximum size, but
we were splitting the Inodes up into smaller chunks for ISO9660 support.  That means that the UDF File Entry actually only had the size for one of the pieces,
not the whole thing.

We fix this by having inodes record their extent_offset, which is always 0 for ISO9660 but will be non-zero for very large UDF files.

Fixes #65 