### PR TITLE
pycdlib-genisoimage: Print after every 400Kb of written data.

### DIFF
--- a/tools/pycdlib-genisoimage
+++ b/tools/pycdlib-genisoimage
@@ -887,9 +887,10 @@ def main():
         A private class to hold onto the data from the last progress call.
         """
 
-        __slots__ = ('last_percent', 'logfp', 'begun')
+        __slots__ = ('done', 'last_percent', 'logfp', 'begun')
 
         def __init__(self, logfp):
+            self.done = 0
             self.last_percent = ''
             self.logfp = logfp
             self.begun = time.time()
@@ -908,13 +909,14 @@ def main():
         """
         frac = float(done) / float(total)
         percent = '%.2f%%' % (frac * 100)
-        if percent != progress_data.last_percent:
+        if percent != progress_data.last_percent and done - progress_data.done > 200 * 2048:
             the_end = time.time()
             if frac > 0:
                 the_end = progress_data.begun + (the_end - progress_data.begun) / frac
             print('%7s done, estimate finish %s' % (percent, time.ctime(the_end)),
                   file=progress_data.logfp)
             progress_data.last_percent = percent
+            progress_data.done = done
 
     iso.write_fp(fp, progress_cb=progress_cb, progress_opaque=ProgressData(logfp))
 


### PR DESCRIPTION
This just makes it print less often, since now the progress callback fires every 2048-byte chunk.