### PR TITLE
Pass custom vol_ident labels through to UDF.

### DIFF
--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -4032,6 +4032,9 @@ class PyCdlib:
 
         if udf:
             self._has_udf = True
+            # If no volume identifier was given, use 'CDROM' as the historical
+            # default for the UDF identifier fields.
+            udf_vol_ident = vol_ident or 'CDROM'
             # Create the UDF Bridge Recognition Volume Sequence.
             udf_bea = udfmod.BEAVolumeStructure()
             udf_bea.new()
@@ -4057,11 +4060,11 @@ class PyCdlib:
 
             # Create the Main Volume Descriptor Sequence.
             pvd = udfmod.UDFPrimaryVolumeDescriptor()
-            pvd.new()
+            pvd.new(udf_vol_ident)
             self.udf_main_descs.pvds.append(pvd)
 
             impl_use = udfmod.UDFImplementationUseVolumeDescriptor()
-            impl_use.new()
+            impl_use.new(udf_vol_ident)
             self.udf_main_descs.impl_use.append(impl_use)
 
             partition = udfmod.UDFPartitionVolumeDescriptor()
@@ -4069,7 +4072,7 @@ class PyCdlib:
             self.udf_main_descs.partitions.append(partition)
 
             logical_volume = udfmod.UDFLogicalVolumeDescriptor()
-            logical_volume.new()
+            logical_volume.new(udf_vol_ident)
             logical_volume.add_partition_map(1)
             self.udf_main_descs.logical_volumes.append(logical_volume)
 
@@ -4083,11 +4086,11 @@ class PyCdlib:
 
             # Create the Reserve Volume Descriptor Sequence.
             reserve_pvd = udfmod.UDFPrimaryVolumeDescriptor()
-            reserve_pvd.new()
+            reserve_pvd.new(udf_vol_ident)
             self.udf_reserve_descs.pvds.append(reserve_pvd)
 
             reserve_impl_use = udfmod.UDFImplementationUseVolumeDescriptor()
-            reserve_impl_use.new()
+            reserve_impl_use.new(udf_vol_ident)
             self.udf_reserve_descs.impl_use.append(reserve_impl_use)
 
             reserve_partition = udfmod.UDFPartitionVolumeDescriptor()
@@ -4095,7 +4098,7 @@ class PyCdlib:
             self.udf_reserve_descs.partitions.append(reserve_partition)
 
             reserve_logical_volume = udfmod.UDFLogicalVolumeDescriptor()
-            reserve_logical_volume.new()
+            reserve_logical_volume.new(udf_vol_ident)
             reserve_logical_volume.add_partition_map(1)
             self.udf_reserve_descs.logical_volumes.append(reserve_logical_volume)
 
@@ -4124,7 +4127,7 @@ class PyCdlib:
             num_bytes_to_add += self.logical_block_size
 
             # Create the File Set
-            self.udf_file_set.new()
+            self.udf_file_set.new(udf_vol_ident)
 
             self.udf_file_set_terminator = udfmod.UDFTerminatingDescriptor()
             self.udf_file_set_terminator.new()

--- a/pycdlib/udf.py
+++ b/pycdlib/udf.py
@@ -1431,13 +1431,13 @@ class UDFPrimaryVolumeDescriptor:
             return self.orig_extent_loc
         return self.new_extent_loc
 
-    def new(self):
-        # type: () -> None
+    def new(self, vol_ident):
+        # type: (str) -> None
         """
         Create a new UDF Primary Volume Descriptor.
 
         Parameters:
-         None.
+         vol_ident - The volume identifier string to use for this descriptor.
         Returns:
          Nothing.
         """
@@ -1449,7 +1449,7 @@ class UDFPrimaryVolumeDescriptor:
 
         self.vol_desc_seqnum = 0  # FIXME: let the user set this
         self.desc_num = 0  # FIXME: let the user set this
-        self.vol_ident = _ostaunicode_zero_pad('CDROM', 32)
+        self.vol_ident = _ostaunicode_zero_pad(vol_ident, 32)
         # According to UDF 2.60, 2.2.2.5, the VolumeSetIdentifier should have
         # at least the first 16 characters be a unique value.  Further, the
         # first 8 bytes of that should be a time value in ASCII hexadecimal
@@ -1576,14 +1576,14 @@ class UDFImplementationUseVolumeDescriptorImplementationUse:
                            self.lv_info1, self.lv_info2, self.lv_info3,
                            self.impl_ident.record(), self.impl_use)
 
-    def new(self):
-        # type: () -> None
+    def new(self, vol_ident):
+        # type: (str) -> None
         """
         Create a new UDF Implementation Use Volume Descriptor Implementation Use
         field.
 
         Parameters:
-         None:
+         vol_ident - The logical volume identifier string to use for this field.
         Returns:
          Nothing.
         """
@@ -1592,7 +1592,7 @@ class UDFImplementationUseVolumeDescriptorImplementationUse:
 
         self.char_set = UDFCharspec()
         self.char_set.new(0, b'OSTA Compressed Unicode')  # FIXME: let the user set this
-        self.log_vol_ident = _ostaunicode_zero_pad('CDROM', 128)
+        self.log_vol_ident = _ostaunicode_zero_pad(vol_ident, 128)
         self.lv_info1 = b'\x00' * 36
         self.lv_info2 = b'\x00' * 36
         self.lv_info3 = b'\x00' * 36
@@ -1698,13 +1698,13 @@ class UDFImplementationUseVolumeDescriptor:
             return self.orig_extent_loc
         return self.new_extent_loc
 
-    def new(self):
-        # type: () -> None
+    def new(self, vol_ident):
+        # type: (str) -> None
         """
         Create a new UDF Implementation Use Volume Descriptor.
 
         Parameters:
-         None:
+         vol_ident - The logical volume identifier string to use for this descriptor.
         Returns:
          Nothing.
         """
@@ -1720,7 +1720,7 @@ class UDFImplementationUseVolumeDescriptor:
         self.impl_ident.new(0, b'*UDF LV Info', b'\x02\x01')
 
         self.impl_use = UDFImplementationUseVolumeDescriptorImplementationUse()
-        self.impl_use.new()
+        self.impl_use.new(vol_ident)
 
         self._initialized = True
 
@@ -2769,13 +2769,13 @@ class UDFLogicalVolumeDescriptor:
             return self.orig_extent_loc
         return self.new_extent_loc
 
-    def new(self):
-        # type: () -> None
+    def new(self, vol_ident):
+        # type: (str) -> None
         """
         Create a new UDF Logical Volume Descriptor.
 
         Parameters:
-         None.
+         vol_ident - The logical volume identifier string to use for this descriptor.
         Returns:
          Nothing.
         """
@@ -2789,7 +2789,7 @@ class UDFLogicalVolumeDescriptor:
         self.desc_char_set = UDFCharspec()
         self.desc_char_set.new(0, b'OSTA Compressed Unicode')  # FIXME: let the user set this
 
-        self.logical_vol_ident = _ostaunicode_zero_pad('CDROM', 128)
+        self.logical_vol_ident = _ostaunicode_zero_pad(vol_ident, 128)
 
         self.domain_ident = UDFEntityID()
         self.domain_ident.new(0, b'*OSTA UDF Compliant', b'\x02\x01\x03')
@@ -3558,13 +3558,14 @@ class UDFFileSetDescriptor:
             return self.orig_extent_loc
         return self.new_extent_loc
 
-    def new(self):
-        # type: () -> None
+    def new(self, vol_ident):
+        # type: (str) -> None
         """
         Create a new UDF File Set Descriptor.
 
         Parameters:
-         None.
+         vol_ident - The logical volume / file set identifier string to use for
+                     this descriptor.
         Returns:
          Nothing.
         """
@@ -3586,10 +3587,10 @@ class UDFFileSetDescriptor:
         self.file_set_num = 0
         self.log_vol_char_set = UDFCharspec()
         self.log_vol_char_set.new(0, b'OSTA Compressed Unicode')  # FIXME: let the user set this
-        self.log_vol_ident = _ostaunicode_zero_pad('CDROM', 128)
+        self.log_vol_ident = _ostaunicode_zero_pad(vol_ident, 128)
         self.file_set_char_set = UDFCharspec()
         self.file_set_char_set.new(0, b'OSTA Compressed Unicode')  # FIXME: let the user set this
-        self.file_set_ident = _ostaunicode_zero_pad('CDROM', 32)
+        self.file_set_ident = _ostaunicode_zero_pad(vol_ident, 32)
         self.copyright_file_ident = b'\x00' * 32  # FIXME: let the user set this
         self.abstract_file_ident = b'\x00' * 32  # FIXME: let the user set this
 

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -4647,6 +4647,35 @@ def test_new_udf_nofiles():
 
     iso.close()
 
+def test_new_udf_custom_vol_ident():
+    # Regression test for https://github.com/clalancette/pycdlib/issues/40.
+    # vol_ident passed to PyCdlib.new() must propagate to the UDF identifier
+    # fields, not just the ISO9660 PVD.
+    iso = pycdlib.PyCdlib()
+    iso.new(udf='2.60', vol_ident='MYDISK')
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    iso2 = pycdlib.PyCdlib()
+    out.seek(0)
+    iso2.open_fp(out)
+
+    expected_32 = b'\x08MYDISK' + b'\x00' * 24 + b'\x07'
+    expected_128 = b'\x08MYDISK' + b'\x00' * 120 + b'\x07'
+
+    assert(iso2.pvd.volume_identifier.rstrip() == b'MYDISK')
+    assert(iso2.udf_main_descs.pvds[0].vol_ident == expected_32)
+    assert(iso2.udf_main_descs.impl_use[0].impl_use.log_vol_ident == expected_128)
+    assert(iso2.udf_main_descs.logical_volumes[0].logical_vol_ident == expected_128)
+    assert(iso2.udf_reserve_descs.pvds[0].vol_ident == expected_32)
+    assert(iso2.udf_reserve_descs.impl_use[0].impl_use.log_vol_ident == expected_128)
+    assert(iso2.udf_reserve_descs.logical_volumes[0].logical_vol_ident == expected_128)
+    assert(iso2.udf_file_set.log_vol_ident == expected_128)
+    assert(iso2.udf_file_set.file_set_ident == expected_32)
+
+    iso2.close()
+
 def test_new_udf_onedir():
     iso = pycdlib.PyCdlib()
     iso.new(udf='2.60')

--- a/tests/unit/test_udf.py
+++ b/tests/unit/test_udf.py
@@ -797,9 +797,9 @@ def test_pvd_extent_location_not_initialized():
 
 def test_pvd_new_initialized_twice():
     pvd = pycdlib.udf.UDFPrimaryVolumeDescriptor()
-    pvd.new()
+    pvd.new('CDROM')
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInternalError) as excinfo:
-        pvd.new()
+        pvd.new('CDROM')
     assert(str(excinfo.value) == 'UDF Primary Volume Descriptor already initialized')
 
 def test_pvd_set_extent_location_not_initialized():
@@ -810,10 +810,10 @@ def test_pvd_set_extent_location_not_initialized():
 
 def test_pvd_equals():
     pvd = pycdlib.udf.UDFPrimaryVolumeDescriptor()
-    pvd.new()
+    pvd.new('CDROM')
 
     pvd2 = pycdlib.udf.UDFPrimaryVolumeDescriptor()
-    pvd2.new()
+    pvd2.new('CDROM')
     pvd2.vol_set_ident = pvd.vol_set_ident
     pvd2.recording_date = pvd.recording_date
 
@@ -821,7 +821,7 @@ def test_pvd_equals():
 
 def test_pvd_eq_not_same_object_type():
     pvd = pycdlib.udf.UDFPrimaryVolumeDescriptor()
-    pvd.new()
+    pvd.new('CDROM')
 
     not_a_pvd = object()
 
@@ -843,23 +843,23 @@ def test_impl_use_impl_use_record_not_initialized():
 
 def test_impl_use_impl_use_new_initialized_twice():
     impl = pycdlib.udf.UDFImplementationUseVolumeDescriptorImplementationUse()
-    impl.new()
+    impl.new('CDROM')
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInternalError) as excinfo:
-        impl.new()
+        impl.new('CDROM')
     assert(str(excinfo.value) == 'UDF Implementation Use Volume Descriptor Implementation Use field already initialized')
 
 def test_impl_use_impl_use_equals():
     impl = pycdlib.udf.UDFImplementationUseVolumeDescriptorImplementationUse()
-    impl.new()
+    impl.new('CDROM')
 
     impl2 = pycdlib.udf.UDFImplementationUseVolumeDescriptorImplementationUse()
-    impl2.new()
+    impl2.new('CDROM')
 
     assert(impl == impl2)
 
 def test_impl_use_impl_use_eq_not_same_object_type():
     impl = pycdlib.udf.UDFImplementationUseVolumeDescriptorImplementationUse()
-    impl.new()
+    impl.new('CDROM')
 
     not_an_impl = object()
 
@@ -897,9 +897,9 @@ def test_impl_use_extent_location_not_initialized():
 
 def test_impl_use_new_initialized_twice():
     impl = pycdlib.udf.UDFImplementationUseVolumeDescriptor()
-    impl.new()
+    impl.new('CDROM')
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInternalError) as excinfo:
-        impl.new()
+        impl.new('CDROM')
     assert(str(excinfo.value) == 'UDF Implementation Use Volume Descriptor already initialized')
 
 def test_impl_use_set_extent_location_not_initialized():
@@ -910,16 +910,16 @@ def test_impl_use_set_extent_location_not_initialized():
 
 def test_impl_use_equals():
     impl = pycdlib.udf.UDFImplementationUseVolumeDescriptor()
-    impl.new()
+    impl.new('CDROM')
 
     impl2 = pycdlib.udf.UDFImplementationUseVolumeDescriptor()
-    impl2.new()
+    impl2.new('CDROM')
 
     assert(impl == impl2)
 
 def test_impl_use_eq_not_same_object_type():
     impl = pycdlib.udf.UDFImplementationUseVolumeDescriptor()
-    impl.new()
+    impl.new('CDROM')
 
     not_an_impl = object()
 
@@ -1456,9 +1456,9 @@ def test_logvoldesc_extent_location_not_initialized():
 
 def test_logvoldesc_new_initialized_twice():
     logvol = pycdlib.udf.UDFLogicalVolumeDescriptor()
-    logvol.new()
+    logvol.new('CDROM')
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInternalError) as excinfo:
-        logvol.new()
+        logvol.new('CDROM')
     assert(str(excinfo.value) == 'UDF Logical Volume Descriptor already initialized')
 
 def test_logvoldesc_add_partition_map_not_initialized():
@@ -1469,26 +1469,26 @@ def test_logvoldesc_add_partition_map_not_initialized():
 
 def test_logvoldesc_add_partition_map_type_0():
     logvol = pycdlib.udf.UDFLogicalVolumeDescriptor()
-    logvol.new()
+    logvol.new('CDROM')
     logvol.add_partition_map(0)
     assert(len(logvol.partition_maps) == 1)
 
 def test_logvoldesc_add_partition_map_type_2():
     logvol = pycdlib.udf.UDFLogicalVolumeDescriptor()
-    logvol.new()
+    logvol.new('CDROM')
     logvol.add_partition_map(2)
     assert(len(logvol.partition_maps) == 1)
 
 def test_logvoldesc_add_partition_map_invalid_type():
     logvol = pycdlib.udf.UDFLogicalVolumeDescriptor()
-    logvol.new()
+    logvol.new('CDROM')
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInternalError) as excinfo:
         logvol.add_partition_map(3)
     assert(str(excinfo.value) == 'UDF Partition map type must be 0, 1, or 2')
 
 def test_logvoldesc_add_partition_map_too_many_maps():
     logvol = pycdlib.udf.UDFLogicalVolumeDescriptor()
-    logvol.new()
+    logvol.new('CDROM')
     logvol.add_partition_map(2)
     logvol.add_partition_map(2)
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInternalError) as excinfo:
@@ -1509,16 +1509,16 @@ def test_logvoldesc_set_integrity_location_not_initialized():
 
 def test_logvoldesc_equals():
     logvol = pycdlib.udf.UDFLogicalVolumeDescriptor()
-    logvol.new()
+    logvol.new('CDROM')
 
     logvol2 = pycdlib.udf.UDFLogicalVolumeDescriptor()
-    logvol2.new()
+    logvol2.new('CDROM')
 
     assert(logvol == logvol2)
 
 def test_logvoldesc_eq_not_same_object_type():
     logvol = pycdlib.udf.UDFLogicalVolumeDescriptor()
-    logvol.new()
+    logvol.new('CDROM')
 
     not_a_logvol = object()
 
@@ -1798,9 +1798,9 @@ def test_file_set_extent_location_not_initialized():
 
 def test_file_set_new_initialized_twice():
     fileset = pycdlib.udf.UDFFileSetDescriptor()
-    fileset.new()
+    fileset.new('CDROM')
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInternalError) as excinfo:
-        fileset.new()
+        fileset.new('CDROM')
     assert(str(excinfo.value) == 'UDF File Set Descriptor already initialized')
 
 def test_file_set_set_extent_location_not_initialized():
@@ -2818,11 +2818,11 @@ def test_descriptor_sequence_append_to_list():
     seq = pycdlib.udf.UDFDescriptorSequence()
 
     pvd1 = pycdlib.udf.UDFPrimaryVolumeDescriptor()
-    pvd1.new()
+    pvd1.new('CDROM')
     seq.append_to_list('pvds', pvd1)
 
     pvd2 = pycdlib.udf.UDFPrimaryVolumeDescriptor()
-    pvd2.new()
+    pvd2.new('CDROM')
     pvd2.desc_num = 1
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidISO) as excinfo:
         seq.append_to_list('pvds', pvd2)


### PR DESCRIPTION
That way the UDF filesystem can use the same name that is passed to the ISO filesystem.

Fixes #40 