### PR TITLE
Update the in-place modification APIs

### DIFF
--- a/pycdlib/__init__.py
+++ b/pycdlib/__init__.py
@@ -3,3 +3,4 @@ Pycdlib is a pure python library to parse, write (master), and create ISO9660
 files.  These files are suitable for writing to a CD or USB.
 """
 from .pycdlib import PyCdlib as PyCdlib  # NOQA, pylint: disable=useless-import-alias
+from .inplaceeditor import InPlaceEditor as InPlaceEditor  # NOQA, pylint: disable=useless-import-alias

--- a/pycdlib/inode.py
+++ b/pycdlib/inode.py
@@ -158,14 +158,19 @@ class Inode:
 
         self.boot_info_table = boot_info_table
 
-    def update_fp(self, fp, length):
-        # type: (BinaryIO, int) -> None
+    def update_fp(self, fp, length, manage_fp=False):
+        # type: (Union[BinaryIO, str], int, bool) -> None
         """
         Update the Inode to use a different file object and length.
 
         Parameters:
-         fp - A file object that contains the data for this Inode.
+         fp - A file object that contains the data for this Inode, or
+              a filename if `manage_fp` is True.
          length - The length of the data.
+         manage_fp - If True, `fp` is treated as a filename that pycdlib
+                     will open and close itself.  If False (the default),
+                     `fp` is a file-like object whose lifetime the caller
+                     manages.
         Returns:
          Nothing.
         """
@@ -176,6 +181,7 @@ class Inode:
         self.data_fp = fp
         self.data_length = length
         self.fp_offset = 0
+        self.manage_fp = manage_fp
 
 
 class InodeOpenData:

--- a/pycdlib/inplaceeditor.py
+++ b/pycdlib/inplaceeditor.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2015-2026 Chris Lalancette <clalancette@gmail.com>
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation;
+# version 2.1 of the License.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+"""
+Focused in-place editing of an existing ISO.
+
+This module hosts the implementation behind PyCdlib's older
+``modify_file_in_place`` method, together with a context-manager-shaped
+public API (:class:`InPlaceEditor`).
+
+The split exists because in-place editing is a fundamentally different
+concept from the mastering APIs on :class:`pycdlib.PyCdlib` (``add_*`` /
+``rm_*`` / ``write_fp``) and combining the two on the same PyCdlib
+object has historically produced silent disk corruption.  Keeping the
+in-place primitives on their own focused class makes the misuse
+impossible to express at the API level: the editor doesn't expose any
+of the mastering methods, so you can't accidentally interleave them.
+"""
+
+from typing import TYPE_CHECKING
+
+from pycdlib import dr
+from pycdlib import inode
+from pycdlib import pycdlibexception
+from pycdlib import udf as udfmod
+from pycdlib import utils
+from pycdlib.pycdlib import PyCdlib
+
+if TYPE_CHECKING:
+    from typing import BinaryIO, Literal, Optional  # noqa: F401
+
+
+def _do_modify_file_in_place(iso, fp, length, iso_path, rr_name=None,  # pylint: disable=unused-argument
+                             joliet_path=None, udf_path=None):          # pylint: disable=unused-argument
+    # type: (PyCdlib, BinaryIO, int, str, Optional[str], Optional[str], Optional[str]) -> None
+    """
+    Implementation of in-place modification of a file's bytes.  Operates
+    on an open :class:`pycdlib.PyCdlib` object's internal state; not a
+    public API.  Used by both :class:`InPlaceEditor` and the deprecated
+    :meth:`pycdlib.PyCdlib.modify_file_in_place` wrapper.
+
+    The constraints documented on the public-facing wrappers apply here:
+    the file must exist on the ISO, must not be a directory, and the new
+    content must occupy the same number of extents as the old content.
+    """
+    if not iso._initialized:  # pylint: disable=protected-access
+        raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
+
+    if hasattr(iso._cdfp, 'mode') and not iso._cdfp.mode.startswith(('r+', 'w', 'a', 'rb+')):  # pylint: disable=protected-access
+        raise pycdlibexception.PyCdlibInvalidInput('To modify a file in place, the original ISO must have been opened in a write mode (r+, w, or a)')
+
+    child = iso._find_iso_record(utils.normpath(iso_path))  # pylint: disable=protected-access
+
+    old_num_extents = utils.ceiling_div(child.get_data_length(),
+                                        iso.logical_block_size)
+    new_num_extents = utils.ceiling_div(length, iso.logical_block_size)
+
+    if old_num_extents != new_num_extents:
+        raise pycdlibexception.PyCdlibInvalidInput('When modifying a file in-place, the number of extents for a file cannot change!')
+
+    if not child.is_file():
+        raise pycdlibexception.PyCdlibInvalidInput('Cannot modify a directory with modify_file_in_place')
+
+    if child.inode is None:
+        raise pycdlibexception.PyCdlibInternalError('Child file found without inode')
+
+    child.inode.update_fp(fp, length)
+
+    # Remove the old size from the PVD size.
+    for pvd in iso.pvds:
+        pvd.remove_from_space_size(child.get_data_length())
+    # And add the new size to the PVD size.
+    for pvd in iso.pvds:
+        pvd.add_to_space_size(length)
+
+    if iso.enhanced_vd is not None:
+        iso.enhanced_vd.copy_sizes(iso.pvd)
+
+    # If we made it here, we have successfully updated all of the in-memory
+    # metadata.  Now we can go and modify the on-disk file.
+
+    iso._seek_to_extent(iso.pvd.extent_location())  # pylint: disable=protected-access
+
+    # First write out the PVD.
+    rec = iso.pvd.record()
+    iso._cdfp.write(rec)  # pylint: disable=protected-access
+
+    # Write out the joliet VD.
+    if iso.joliet_vd is not None:
+        iso._seek_to_extent(iso.joliet_vd.extent_location())  # pylint: disable=protected-access
+        rec = iso.joliet_vd.record()
+        iso._cdfp.write(rec)  # pylint: disable=protected-access
+
+    # Write out the enhanced VD.
+    if iso.enhanced_vd is not None:
+        iso._seek_to_extent(iso.enhanced_vd.extent_location())  # pylint: disable=protected-access
+        rec = iso.enhanced_vd.record()
+        iso._cdfp.write(rec)  # pylint: disable=protected-access
+
+    # We don't have to write anything out for UDF since it only tracks
+    # extents, and we know we aren't changing the number of extents.
+
+    # Write out the actual file contents.
+    iso._seek_to_extent(child.extent_location())  # pylint: disable=protected-access
+    with inode.InodeOpenData(child.inode, iso.logical_block_size) as (data_fp, data_len):
+        utils.copy_data(data_len, iso.logical_block_size, data_fp, iso._cdfp)  # pylint: disable=protected-access
+        utils.zero_pad(iso._cdfp, data_len, iso.logical_block_size)  # pylint: disable=protected-access
+
+    # Finally update the directory record entries that reference this
+    # file with the new length.  For UDF the file entry has its own
+    # extent, so we can write it directly.  For ISO9660/Joliet the
+    # record lives inside its parent's directory extent; we used to
+    # compute that record's byte offset from extents_to_here /
+    # offset_to_here (which reflect pycdlib's in-memory sorted order
+    # of children), but the on-disk order doesn't always match the
+    # sorted order -- writing to the computed offset then corrupts
+    # whichever sibling actually sits at that on-disk position
+    # (issue #122).  Rewrite the parent's full child list instead.
+    first_joliet = True
+    rewritten_parents = set()  # type: set
+    for record, is_pvd_unused in child.inode.linked_records:
+        if isinstance(record, dr.DirectoryRecord):
+            if iso.joliet_vd is not None and id(record.vd) == id(iso.joliet_vd) and first_joliet:
+                first_joliet = False
+                iso.joliet_vd.remove_from_space_size(record.get_data_length())
+                iso.joliet_vd.add_to_space_size(length)
+            if record.parent is None:
+                raise pycdlibexception.PyCdlibInternalError('Modifying file with empty parent')
+            record.set_data_length(length)
+            # Walk up the parent chain, rewriting each ancestor's
+            # extent.  The immediate parent's rewrite captures the
+            # modified file's new data_length; each higher
+            # ancestor's rewrite captures the data_length of its
+            # child (which may have shrunk via _remove_child's
+            # underflow handler when a sibling was removed).
+            # Without the up-walk, an in-memory data_length change
+            # never reaches the on-disk record that the parser
+            # uses to bound the data extent, and the parser reads
+            # stale bytes from a dropped extent.  We stop at the
+            # root: the root's data_length lives in the PVD's
+            # root_directory_record, which is already written out
+            # earlier in this function.
+            node = record.parent  # type: Optional[dr.DirectoryRecord]
+            while node is not None and id(node) not in rewritten_parents:
+                rewritten_parents.add(id(node))
+                iso._rewrite_dir_record_extent(node)  # pylint: disable=protected-access
+                # Each subdirectory of `node` has a dotdot record
+                # (in its own extent) whose data_length carries
+                # node.data_length.  _add_child / _remove_child
+                # keep those dotdots in sync in memory, but the
+                # bytes on disk haven't been touched unless we
+                # rewrite them here.
+                iso._rewrite_subdir_dotdots(node)  # pylint: disable=protected-access
+                node = node.parent
+        elif isinstance(record, udfmod.UDFFileEntry):
+            record.set_data_length(length)
+            abs_offset = record.extent_location() * iso.logical_block_size
+            iso._cdfp.seek(abs_offset)  # pylint: disable=protected-access
+            iso._cdfp.write(record.record())  # pylint: disable=protected-access
+        else:
+            # This should never happen
+            raise pycdlibexception.PyCdlibInternalError('Invalid record type')
+
+
+class InPlaceEditor:
+    """
+    Context manager for editing files in place on an existing ISO.
+
+    Open the ISO, modify one or more files in place, and close.  The
+    new content is written to the *original* ISO file -- there is no
+    separate output file the way ``write_fp`` produces.
+    """
+
+    __slots__ = ('_iso',)
+
+    def __init__(self, filename, mode='rb+'):
+        # type: (str, str) -> None
+        """
+        Open `filename` for in-place editing.
+
+        Parameters:
+         filename - The local filesystem path to the ISO file to edit.
+         mode - The mode to open the ISO file in.  Must permit writing;
+                defaults to ``'rb+'``.
+        Returns:
+         Nothing.
+        """
+        self._iso = PyCdlib()
+        self._iso.open(filename, mode=mode)
+
+    def __enter__(self):
+        # type: () -> InPlaceEditor
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # type: (object, object, object) -> Literal[False]
+        self._iso.close()
+        return False  # don't suppress exceptions
+
+    def modify_file(self, fp, length, iso_path, rr_name=None,  # pylint: disable=unused-argument
+                    joliet_path=None, udf_path=None):          # pylint: disable=unused-argument
+        # type: (BinaryIO, int, str, Optional[str], Optional[str], Optional[str]) -> None
+        """
+        Replace the bytes of an existing file on the ISO with new content.
+
+        Constraints:
+         - The file must already exist on the ISO.
+         - The file must not be a directory.
+         - The new content must occupy the same number of extents as
+           the old content.
+
+        Parameters:
+         fp - A file-like object containing the new contents.
+         length - The length of the new contents.
+         iso_path - The ISO9660 absolute path identifying the file.
+         rr_name - Rock Ridge name (accepted for API symmetry; not used
+                   for lookup).
+         joliet_path - Joliet absolute path (accepted for API symmetry;
+                       not used for lookup).
+         udf_path - UDF absolute path (accepted for API symmetry; not
+                    used for lookup).
+        Returns:
+         Nothing.
+        """
+        _do_modify_file_in_place(self._iso, fp, length, iso_path,
+                                 rr_name=rr_name,
+                                 joliet_path=joliet_path,
+                                 udf_path=udf_path)

--- a/pycdlib/inplaceeditor.py
+++ b/pycdlib/inplaceeditor.py
@@ -288,8 +288,8 @@ def _do_rm_file(iso, iso_path):
 
 
 def _do_add_fp(iso, data_source, length, manage_fp, iso_path,
-               joliet_path=None, file_mode=None):
-    # type: (PyCdlib, Union[BinaryIO, str], int, bool, str, Optional[str], Optional[int]) -> None
+               rr_name=None, joliet_path=None, file_mode=None):
+    # type: (PyCdlib, Union[BinaryIO, str], int, bool, str, Optional[str], Optional[str], Optional[int]) -> None
     """
     Implementation of in-place file addition.  Operates on an open
     :class:`pycdlib.PyCdlib` object's internal state; not a public API.
@@ -302,10 +302,14 @@ def _do_add_fp(iso, data_source, length, manage_fp, iso_path,
     extent must have enough slack to hold one more record.
 
     Refuses on:
-     - UDF, Rock Ridge, or El Torito ISOs (out of scope for v1).
+     - UDF or El Torito ISOs (out of scope for v1).
      - A target path whose parent's directory extent would need to
        grow to fit the new record (would require relocating the parent,
        cascading layout changes).
+     - Rock Ridge metadata that would require allocating a new
+       Continuation Entry (CE) block -- this happens when the SUSP
+       fields don't fit inside the directory record (e.g., very long
+       ``rr_name``).  Short-name Rock Ridge is supported.
     """
     if not iso._initialized:  # pylint: disable=protected-access
         raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
@@ -315,10 +319,15 @@ def _do_add_fp(iso, data_source, length, manage_fp, iso_path,
 
     if iso.udf_root is not None:
         raise pycdlibexception.PyCdlibInvalidInput('InPlaceEditor.add_fp does not support UDF ISOs yet; use PyCdlib.add_fp + write_fp() to produce a new ISO instead')
-    if iso.rock_ridge:
-        raise pycdlibexception.PyCdlibInvalidInput('InPlaceEditor.add_fp does not support Rock Ridge ISOs yet; use PyCdlib.add_fp + write_fp() to produce a new ISO instead')
     if iso.eltorito_boot_catalog is not None:
         raise pycdlibexception.PyCdlibInvalidInput('InPlaceEditor.add_fp does not support El Torito ISOs yet; use PyCdlib.add_fp + write_fp() to produce a new ISO instead')
+
+    # Rock Ridge: rr_name must be present iff the ISO is Rock Ridge,
+    # matching PyCdlib.add_fp's contract.
+    if iso.rock_ridge and rr_name is None:
+        raise pycdlibexception.PyCdlibInvalidInput('Must specify an rr_name when adding a file to a Rock Ridge ISO')
+    if not iso.rock_ridge and rr_name is not None:
+        raise pycdlibexception.PyCdlibInvalidInput('Cannot specify an rr_name on a non-Rock-Ridge ISO')
 
     # Resolve the ISO9660 path's parent and leaf name.
     iso_path_bytes = utils.normpath(iso_path)
@@ -336,25 +345,39 @@ def _do_add_fp(iso, data_source, length, manage_fp, iso_path,
     # Reserve the new file's data extent at the current end of the ISO.
     new_data_extent = iso.pvd.space_size
 
-    fmode = file_mode if file_mode is not None else 0
+    # Default Rock Ridge file mode matches PyCdlib's add_fp default
+    # for managed-fp callers (regular file, r--r--r--).
+    if file_mode is None:
+        fmode = 0o0100444 if iso.rock_ridge else 0
+    else:
+        fmode = file_mode
 
     # Create the shared Inode that backs every linked record.
     ino = inode.Inode()
     ino.new(length, data_source, manage_fp, 0)
     ino.set_extent_location(new_data_extent)
 
-    # Create the ISO9660 directory record, link it to the inode, and
-    # attempt to add it to the parent's children list.  add_child
-    # returns True if the parent would have to grow its data_length to
-    # fit the new record -- in-place is a fixed-allocation primitive,
-    # so we treat that as a hard failure and roll the change back.
+    # Create the ISO9660 directory record.  For a Rock Ridge ISO we
+    # pass the version and rr_name through so the SUSP entries land in
+    # the record; for a plain ISO9660 ISO we pass empty placeholders.
+    rr_version = iso.rock_ridge if iso.rock_ridge else ''
+    rr_name_bytes = rr_name.encode('utf-8') if rr_name is not None else b''
+
     new_iso_rec = dr.DirectoryRecord()
     new_iso_rec.new_file(iso.pvd, length, iso_name, iso_parent,
                          iso.pvd.sequence_number(),
-                         '', b'', iso.xa, fmode,
+                         rr_version, rr_name_bytes, iso.xa, fmode,
                          time.time(), None)
     new_iso_rec.set_data_location(new_data_extent, 0)
     new_iso_rec.inode = ino
+
+    # If Rock Ridge couldn't fit all its SUSP fields inline, the
+    # record now has a CE (Continuation Entry) referencing a separate
+    # block.  In-place add can't grow the on-disk RR CE allocation, so
+    # we refuse the add up front.  Catch this *before* mutating the
+    # parent so there's nothing to roll back.
+    if new_iso_rec.rock_ridge is not None and new_iso_rec.rock_ridge.dr_entries.ce_record is not None:
+        raise pycdlibexception.PyCdlibInvalidInput("Adding this file requires a Rock Ridge Continuation Entry (CE) block, which in-place add cannot allocate; use PyCdlib.add_fp + write_fp() to produce a new ISO instead")
 
     iso_overflowed = iso_parent.add_child(new_iso_rec, iso.logical_block_size)
     if iso_overflowed:
@@ -517,8 +540,9 @@ class InPlaceEditor:
         """
         _do_rm_file(self._iso, iso_path)
 
-    def add_fp(self, fp, length, iso_path, joliet_path=None, file_mode=None):
-        # type: (BinaryIO, int, str, Optional[str], Optional[int]) -> None
+    def add_fp(self, fp, length, iso_path, rr_name=None, joliet_path=None,
+               file_mode=None):
+        # type: (BinaryIO, int, str, Optional[str], Optional[str], Optional[int]) -> None
         """
         Add a new file to the ISO in place, reading the content from
         a file-like object.
@@ -529,8 +553,12 @@ class InPlaceEditor:
         existing extent on disk.
 
         Constraints:
-         - The ISO must not be a UDF, Rock Ridge, or El Torito ISO
-           (out of scope for v1).
+         - The ISO must not be a UDF or El Torito ISO (out of scope
+           for v1).
+         - On a Rock Ridge ISO, ``rr_name`` must be provided.  Rock
+           Ridge SUSP fields whose serialized length would require a
+           new Continuation Entry block are refused (this typically
+           means very long ``rr_name`` values; short names are fine).
          - The target's parent directory must already exist on the ISO.
          - The parent's directory extent must have enough slack to
            hold one more record; if not, this raises and you must use
@@ -543,18 +571,22 @@ class InPlaceEditor:
          length - The length of the new content.
          iso_path - The ISO9660 absolute path identifying where to
                     insert the file.
+         rr_name - Rock Ridge name; required on Rock Ridge ISOs and
+                   rejected on non-Rock-Ridge ISOs.
          joliet_path - The Joliet absolute path; if provided, a Joliet
                        directory record is also inserted.
-         file_mode - File-mode bits (ignored on non-Rock-Ridge ISOs;
-                     since v1 refuses Rock Ridge, this is informational).
+         file_mode - File-mode bits (Rock Ridge only).
         Returns:
          Nothing.
         """
         _do_add_fp(self._iso, fp, length, False, iso_path,
-                   joliet_path=joliet_path, file_mode=file_mode)
+                   rr_name=rr_name,
+                   joliet_path=joliet_path,
+                   file_mode=file_mode)
 
-    def add_file(self, filename, iso_path, joliet_path=None, file_mode=None):
-        # type: (str, str, Optional[str], Optional[int]) -> None
+    def add_file(self, filename, iso_path, rr_name=None, joliet_path=None,
+                 file_mode=None):
+        # type: (str, str, Optional[str], Optional[str], Optional[int]) -> None
         """
         Add a new file to the ISO in place, reading the content from
         a file on the local filesystem.
@@ -569,12 +601,17 @@ class InPlaceEditor:
                     file's content on the ISO.
          iso_path - The ISO9660 absolute path identifying where to
                     insert the file.
+         rr_name - Rock Ridge name; required on Rock Ridge ISOs and
+                   rejected on non-Rock-Ridge ISOs.
          joliet_path - The Joliet absolute path; if provided, a Joliet
                        directory record is also inserted.
-         file_mode - File-mode bits (ignored on non-Rock-Ridge ISOs).
+         file_mode - File-mode bits (Rock Ridge only).
         Returns:
          Nothing.
         """
         import os  # pylint: disable=import-outside-toplevel
         _do_add_fp(self._iso, filename, os.stat(filename).st_size, True,
-                   iso_path, joliet_path=joliet_path, file_mode=file_mode)
+                   iso_path,
+                   rr_name=rr_name,
+                   joliet_path=joliet_path,
+                   file_mode=file_mode)

--- a/pycdlib/inplaceeditor.py
+++ b/pycdlib/inplaceeditor.py
@@ -68,8 +68,13 @@ def _do_modify_file_in_place(iso, fp, length, iso_path, rr_name=None,  # pylint:
                                         iso.logical_block_size)
     new_num_extents = utils.ceiling_div(length, iso.logical_block_size)
 
-    if old_num_extents != new_num_extents:
-        raise pycdlibexception.PyCdlibInvalidInput('When modifying a file in-place, the number of extents for a file cannot change!')
+    # Growing the file's extent count is rejected: the next on-disk
+    # extent belongs to whatever sits after this file in the volume
+    # layout, and writing into it would corrupt that data.  Shrinking
+    # is allowed -- the orphaned extents inside the file's original
+    # allocation get zeroed below so we don't leak the old content.
+    if new_num_extents > old_num_extents:
+        raise pycdlibexception.PyCdlibInvalidInput('When modifying a file in-place, the number of extents for a file cannot grow!')
 
     if not child.is_file():
         raise pycdlibexception.PyCdlibInvalidInput('Cannot modify a directory with modify_file_in_place')
@@ -79,15 +84,12 @@ def _do_modify_file_in_place(iso, fp, length, iso_path, rr_name=None,  # pylint:
 
     child.inode.update_fp(fp, length)
 
-    # Remove the old size from the PVD size.
-    for pvd in iso.pvds:
-        pvd.remove_from_space_size(child.get_data_length())
-    # And add the new size to the PVD size.
-    for pvd in iso.pvds:
-        pvd.add_to_space_size(length)
-
-    if iso.enhanced_vd is not None:
-        iso.enhanced_vd.copy_sizes(iso.pvd)
+    # The file's on-disk extent allocation does not change: even on a
+    # shrink, the orphaned extents stay part of the volume (just
+    # unreferenced).  So we deliberately do not adjust PVD or Joliet
+    # space_size here -- decreasing them would tell the parser the
+    # volume is smaller than it is, truncating any file laid out past
+    # the file we just shrunk.
 
     # If we made it here, we have successfully updated all of the in-memory
     # metadata.  Now we can go and modify the on-disk file.
@@ -110,14 +112,24 @@ def _do_modify_file_in_place(iso, fp, length, iso_path, rr_name=None,  # pylint:
         rec = iso.enhanced_vd.record()
         iso._cdfp.write(rec)  # pylint: disable=protected-access
 
-    # We don't have to write anything out for UDF since it only tracks
-    # extents, and we know we aren't changing the number of extents.
+    # The UDF anchors, descriptors, and partition length aren't
+    # affected -- the file's on-disk extent allocation is unchanged.
+    # Only the UDF File Entry's data_length needs updating, which we
+    # handle below alongside the ISO9660/Joliet records.
 
     # Write out the actual file contents.
     iso._seek_to_extent(child.extent_location())  # pylint: disable=protected-access
     with inode.InodeOpenData(child.inode, iso.logical_block_size) as (data_fp, data_len):
         utils.copy_data(data_len, iso.logical_block_size, data_fp, iso._cdfp)  # pylint: disable=protected-access
         utils.zero_pad(iso._cdfp, data_len, iso.logical_block_size)  # pylint: disable=protected-access
+
+    # If the new content uses fewer extents than the old, the file's
+    # original allocation still holds the tail of the old content past
+    # the new (now shorter) data length.  Zero those orphaned extents
+    # so we don't leak the old data into the volume.
+    if new_num_extents < old_num_extents:
+        orphan_extents = old_num_extents - new_num_extents
+        iso._cdfp.write(b'\x00' * (orphan_extents * iso.logical_block_size))  # pylint: disable=protected-access
 
     # Finally update the directory record entries that reference this
     # file with the new length.  For UDF the file entry has its own
@@ -129,14 +141,9 @@ def _do_modify_file_in_place(iso, fp, length, iso_path, rr_name=None,  # pylint:
     # sorted order -- writing to the computed offset then corrupts
     # whichever sibling actually sits at that on-disk position
     # (issue #122).  Rewrite the parent's full child list instead.
-    first_joliet = True
     rewritten_parents = set()  # type: set
     for record, is_pvd_unused in child.inode.linked_records:
         if isinstance(record, dr.DirectoryRecord):
-            if iso.joliet_vd is not None and id(record.vd) == id(iso.joliet_vd) and first_joliet:
-                first_joliet = False
-                iso.joliet_vd.remove_from_space_size(record.get_data_length())
-                iso.joliet_vd.add_to_space_size(length)
             if record.parent is None:
                 raise pycdlibexception.PyCdlibInternalError('Modifying file with empty parent')
             record.set_data_length(length)
@@ -219,8 +226,12 @@ class InPlaceEditor:
         Constraints:
          - The file must already exist on the ISO.
          - The file must not be a directory.
-         - The new content must occupy the same number of extents as
-           the old content.
+         - The new content cannot occupy more extents than the old
+           content.  Within that ceiling the new length is free: a
+           file currently sized to N extents may be replaced with any
+           content from 0 bytes up through N*logical_block_size bytes.
+           Shrinking past an extent boundary zeroes the orphaned
+           extents inside the file's original on-disk allocation.
 
         Parameters:
          fp - A file-like object containing the new contents.

--- a/pycdlib/inplaceeditor.py
+++ b/pycdlib/inplaceeditor.py
@@ -30,6 +30,7 @@ impossible to express at the API level: the editor doesn't expose any
 of the mastering methods, so you can't accidentally interleave them.
 """
 
+import time
 from typing import TYPE_CHECKING
 
 from pycdlib import dr
@@ -40,7 +41,7 @@ from pycdlib import utils
 from pycdlib.pycdlib import PyCdlib
 
 if TYPE_CHECKING:
-    from typing import BinaryIO, Literal, Optional  # noqa: F401
+    from typing import BinaryIO, Literal, Optional, Union  # noqa: F401
 
 
 def _do_modify_file_in_place(iso, fp, length, iso_path, rr_name=None,  # pylint: disable=unused-argument
@@ -182,6 +183,245 @@ def _do_modify_file_in_place(iso, fp, length, iso_path, rr_name=None,  # pylint:
             raise pycdlibexception.PyCdlibInternalError('Invalid record type')
 
 
+def _do_rm_file(iso, iso_path):
+    # type: (PyCdlib, str) -> None
+    """
+    Implementation of in-place file removal.  Operates on an open
+    :class:`pycdlib.PyCdlib` object's internal state; not a public API.
+    Used by :meth:`InPlaceEditor.rm_file`.
+
+    Removes the file's directory record(s) from every tree the file
+    is linked into (ISO9660 and Joliet) and rewrites the affected
+    parent extents on disk.  The file's data extent stays as orphaned
+    bytes inside the volume -- PVD ``space_size`` is not adjusted
+    because the on-disk extent allocation doesn't change.
+
+    Refuses on:
+     - UDF (out of scope for v1).
+     - Directories.
+     - Files referenced by El Torito (the boot catalog itself or any
+       boot image entry).
+    """
+    if not iso._initialized:  # pylint: disable=protected-access
+        raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
+
+    if hasattr(iso._cdfp, 'mode') and not iso._cdfp.mode.startswith(('r+', 'w', 'a', 'rb+')):  # pylint: disable=protected-access
+        raise pycdlibexception.PyCdlibInvalidInput('To modify a file in place, the original ISO must have been opened in a write mode (r+, w, or a)')
+
+    if iso.udf_root is not None:
+        raise pycdlibexception.PyCdlibInvalidInput('InPlaceEditor.rm_file does not support UDF ISOs yet; use PyCdlib.rm_file + write_fp() to produce a new ISO instead')
+
+    child = iso._find_iso_record(utils.normpath(iso_path))  # pylint: disable=protected-access
+
+    if not child.is_file():
+        raise pycdlibexception.PyCdlibInvalidInput('Cannot remove a directory with rm_file')
+
+    if iso.eltorito_boot_catalog is not None:
+        if any(id(child) == id(rec) for rec in iso.eltorito_boot_catalog.dirrecords):
+            raise pycdlibexception.PyCdlibInvalidInput("Cannot remove a file that is the El Torito boot catalog; use PyCdlib.rm_eltorito + write_fp() to produce a new ISO instead")
+        if child.inode is not None:
+            iso._check_inode_against_eltorito(child.inode)  # pylint: disable=protected-access
+
+    # Collect each linked record's parent before removal -- after
+    # _rm_dr_link runs, the record is no longer in inode.linked_records
+    # so we'd lose track of which parents got affected.
+    affected_parents = []
+    seen_parents = set()  # type: set
+    if child.inode is not None:
+        for record, _is_pvd in child.inode.linked_records:
+            if isinstance(record, dr.DirectoryRecord):
+                parent = record.parent
+                if id(parent) not in seen_parents:
+                    seen_parents.add(id(parent))
+                    affected_parents.append(parent)
+            else:
+                raise pycdlibexception.PyCdlibInternalError('Unsupported linked record type for in-place rm_file')
+
+    # Remove from the in-memory tree.  _rm_dr_link does the per-record
+    # bookkeeping (removes from parent.children, removes from
+    # inode.linked_records, drops the inode when no more references
+    # remain, walks data_continuation chains for multi-extent files).
+    if child.inode is None:
+        iso._remove_child_from_dr(child, child.index_in_parent)  # pylint: disable=protected-access
+        if id(child.parent) not in seen_parents:
+            seen_parents.add(id(child.parent))
+            affected_parents.append(child.parent)
+    else:
+        while child.inode.linked_records:
+            rec = child.inode.linked_records[0][0]
+            if isinstance(rec, dr.DirectoryRecord):
+                iso._rm_dr_link(rec)  # pylint: disable=protected-access
+            else:
+                raise pycdlibexception.PyCdlibInternalError('Unsupported linked record type for in-place rm_file')
+
+    # Commit the change to disk.  Rewrite each affected parent's
+    # directory extent (the existing _rewrite_dir_record_extent
+    # zero-pads trailing bytes so the removed record's tail doesn't
+    # leak through), then walk up each parent's ancestor chain to
+    # propagate any data_length shrinkage from _remove_child's
+    # underflow handler.
+    rewritten = set()  # type: set
+    for parent in affected_parents:
+        node = parent  # type: Optional[dr.DirectoryRecord]
+        while node is not None and id(node) not in rewritten:
+            rewritten.add(id(node))
+            iso._rewrite_dir_record_extent(node)  # pylint: disable=protected-access
+            iso._rewrite_subdir_dotdots(node)  # pylint: disable=protected-access
+            node = node.parent
+
+    # Write the updated PVDs and Joliet VD back to disk.  The on-disk
+    # space_size is unchanged (the data extent is orphaned, not
+    # freed) but other fields embedded in the VDs -- the root
+    # directory record's data_length, for instance -- may have shifted
+    # if the up-walk reached root.
+    iso._seek_to_extent(iso.pvd.extent_location())  # pylint: disable=protected-access
+    iso._cdfp.write(iso.pvd.record())  # pylint: disable=protected-access
+
+    if iso.joliet_vd is not None:
+        iso._seek_to_extent(iso.joliet_vd.extent_location())  # pylint: disable=protected-access
+        iso._cdfp.write(iso.joliet_vd.record())  # pylint: disable=protected-access
+
+    if iso.enhanced_vd is not None:
+        iso.enhanced_vd.copy_sizes(iso.pvd)
+        iso._seek_to_extent(iso.enhanced_vd.extent_location())  # pylint: disable=protected-access
+        iso._cdfp.write(iso.enhanced_vd.record())  # pylint: disable=protected-access
+
+
+def _do_add_fp(iso, data_source, length, manage_fp, iso_path,
+               joliet_path=None, file_mode=None):
+    # type: (PyCdlib, Union[BinaryIO, str], int, bool, str, Optional[str], Optional[int]) -> None
+    """
+    Implementation of in-place file addition.  Operates on an open
+    :class:`pycdlib.PyCdlib` object's internal state; not a public API.
+    Used by :meth:`InPlaceEditor.add_fp` and :meth:`InPlaceEditor.add_file`.
+
+    The new file's data extent is allocated at the current end of the
+    ISO (``pvd.space_size``), so the on-disk file grows by exactly the
+    space the new content needs.  The new file's directory record is
+    inserted into the parent's existing extent on disk; the parent
+    extent must have enough slack to hold one more record.
+
+    Refuses on:
+     - UDF, Rock Ridge, or El Torito ISOs (out of scope for v1).
+     - A target path whose parent's directory extent would need to
+       grow to fit the new record (would require relocating the parent,
+       cascading layout changes).
+    """
+    if not iso._initialized:  # pylint: disable=protected-access
+        raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
+
+    if hasattr(iso._cdfp, 'mode') and not iso._cdfp.mode.startswith(('r+', 'w', 'a', 'rb+')):  # pylint: disable=protected-access
+        raise pycdlibexception.PyCdlibInvalidInput('To modify a file in place, the original ISO must have been opened in a write mode (r+, w, or a)')
+
+    if iso.udf_root is not None:
+        raise pycdlibexception.PyCdlibInvalidInput('InPlaceEditor.add_fp does not support UDF ISOs yet; use PyCdlib.add_fp + write_fp() to produce a new ISO instead')
+    if iso.rock_ridge:
+        raise pycdlibexception.PyCdlibInvalidInput('InPlaceEditor.add_fp does not support Rock Ridge ISOs yet; use PyCdlib.add_fp + write_fp() to produce a new ISO instead')
+    if iso.eltorito_boot_catalog is not None:
+        raise pycdlibexception.PyCdlibInvalidInput('InPlaceEditor.add_fp does not support El Torito ISOs yet; use PyCdlib.add_fp + write_fp() to produce a new ISO instead')
+
+    # Resolve the ISO9660 path's parent and leaf name.
+    iso_path_bytes = utils.normpath(iso_path)
+    (iso_name, iso_parent) = iso._iso_name_and_parent_from_path(iso_path_bytes)  # pylint: disable=protected-access
+
+    # Resolve the Joliet path's parent and leaf name (if provided).
+    joliet_parent = None  # type: Optional[dr.DirectoryRecord]
+    joliet_name = None  # type: Optional[bytes]
+    if joliet_path is not None:
+        if iso.joliet_vd is None:
+            raise pycdlibexception.PyCdlibInvalidInput('Cannot use joliet_path on a non-Joliet ISO')
+        joliet_path_bytes = iso._normalize_joliet_path(joliet_path)  # pylint: disable=protected-access
+        (joliet_name, joliet_parent) = iso._joliet_name_and_parent_from_path(joliet_path_bytes)  # pylint: disable=protected-access
+
+    # Reserve the new file's data extent at the current end of the ISO.
+    new_data_extent = iso.pvd.space_size
+
+    fmode = file_mode if file_mode is not None else 0
+
+    # Create the shared Inode that backs every linked record.
+    ino = inode.Inode()
+    ino.new(length, data_source, manage_fp, 0)
+    ino.set_extent_location(new_data_extent)
+
+    # Create the ISO9660 directory record, link it to the inode, and
+    # attempt to add it to the parent's children list.  add_child
+    # returns True if the parent would have to grow its data_length to
+    # fit the new record -- in-place is a fixed-allocation primitive,
+    # so we treat that as a hard failure and roll the change back.
+    new_iso_rec = dr.DirectoryRecord()
+    new_iso_rec.new_file(iso.pvd, length, iso_name, iso_parent,
+                         iso.pvd.sequence_number(),
+                         '', b'', iso.xa, fmode,
+                         time.time(), None)
+    new_iso_rec.set_data_location(new_data_extent, 0)
+    new_iso_rec.inode = ino
+
+    iso_overflowed = iso_parent.add_child(new_iso_rec, iso.logical_block_size)
+    if iso_overflowed:
+        iso_parent.remove_child(new_iso_rec, new_iso_rec.index_in_parent, iso.logical_block_size)
+        raise pycdlibexception.PyCdlibInvalidInput("Adding this file would overflow the parent directory's extent; use PyCdlib.add_fp + write_fp() to produce a new ISO instead")
+    ino.linked_records.append((new_iso_rec, True))
+
+    # Joliet record, if requested.  Same overflow check.
+    if joliet_parent is not None and iso.joliet_vd is not None and joliet_name is not None:
+        new_joliet_rec = dr.DirectoryRecord()
+        new_joliet_rec.new_file(iso.joliet_vd, length, joliet_name, joliet_parent,
+                                iso.joliet_vd.sequence_number(),
+                                '', b'', False, 0, time.time(), None)
+        new_joliet_rec.set_data_location(new_data_extent, 0)
+        new_joliet_rec.inode = ino
+
+        joliet_overflowed = joliet_parent.add_child(new_joliet_rec, iso.logical_block_size)
+        if joliet_overflowed:
+            joliet_parent.remove_child(new_joliet_rec, new_joliet_rec.index_in_parent, iso.logical_block_size)
+            # Roll the ISO9660 side back too so the failure is atomic.
+            iso_parent.remove_child(new_iso_rec, new_iso_rec.index_in_parent, iso.logical_block_size)
+            ino.linked_records.remove((new_iso_rec, True))
+            raise pycdlibexception.PyCdlibInvalidInput("Adding this file would overflow the Joliet parent directory's extent; use PyCdlib.add_fp + write_fp() to produce a new ISO instead")
+        ino.linked_records.append((new_joliet_rec, False))
+
+    # The in-memory tree update succeeded; register the inode.
+    iso.inodes.append(ino)
+
+    # Grow PVD / Joliet / Enhanced VD space_size to cover the new
+    # file's data extent.  These take bytes and round up internally.
+    iso.pvd.add_to_space_size(length)
+    if iso.joliet_vd is not None:
+        iso.joliet_vd.add_to_space_size(length)
+    if iso.enhanced_vd is not None:
+        iso.enhanced_vd.copy_sizes(iso.pvd)
+
+    # Commit to disk: write the file data at the reserved extent.
+    iso._seek_to_extent(new_data_extent)  # pylint: disable=protected-access
+    if isinstance(data_source, str):
+        with open(data_source, 'rb') as fp:
+            utils.copy_data(length, iso.logical_block_size, fp, iso._cdfp)  # pylint: disable=protected-access
+    else:
+        utils.copy_data(length, iso.logical_block_size, data_source, iso._cdfp)  # pylint: disable=protected-access
+    utils.zero_pad(iso._cdfp, length, iso.logical_block_size)  # pylint: disable=protected-access
+
+    # Rewrite each affected parent's directory extent on disk so the
+    # new record becomes visible to a future parser.
+    iso._rewrite_dir_record_extent(iso_parent)  # pylint: disable=protected-access
+    iso._rewrite_subdir_dotdots(iso_parent)  # pylint: disable=protected-access
+    if joliet_parent is not None:
+        iso._rewrite_dir_record_extent(joliet_parent)  # pylint: disable=protected-access
+        iso._rewrite_subdir_dotdots(joliet_parent)  # pylint: disable=protected-access
+
+    # Write the updated PVD / Joliet VD / Enhanced VD back so the
+    # bumped space_size lands on disk.
+    iso._seek_to_extent(iso.pvd.extent_location())  # pylint: disable=protected-access
+    iso._cdfp.write(iso.pvd.record())  # pylint: disable=protected-access
+
+    if iso.joliet_vd is not None:
+        iso._seek_to_extent(iso.joliet_vd.extent_location())  # pylint: disable=protected-access
+        iso._cdfp.write(iso.joliet_vd.record())  # pylint: disable=protected-access
+
+    if iso.enhanced_vd is not None:
+        iso._seek_to_extent(iso.enhanced_vd.extent_location())  # pylint: disable=protected-access
+        iso._cdfp.write(iso.enhanced_vd.record())  # pylint: disable=protected-access
+
+
 class InPlaceEditor:
     """
     Context manager for editing files in place on an existing ISO.
@@ -250,3 +490,91 @@ class InPlaceEditor:
                                  rr_name=rr_name,
                                  joliet_path=joliet_path,
                                  udf_path=udf_path)
+
+    def rm_file(self, iso_path):
+        # type: (str) -> None
+        """
+        Remove a file from the ISO in place.
+
+        The file's directory record is removed from every tree the
+        file is linked into (ISO9660 and Joliet) and the affected
+        parent extents are rewritten on disk.  The file's data extent
+        stays as orphaned bytes inside the volume -- the volume's
+        on-disk size doesn't shrink.
+
+        Constraints:
+         - The path must identify an existing file.
+         - The file must not be a directory.
+         - The file must not be referenced by El Torito (use
+           :meth:`pycdlib.PyCdlib.rm_eltorito` first).
+         - The ISO must not be a UDF ISO (UDF in-place rm is not
+           supported yet).
+
+        Parameters:
+         iso_path - The ISO9660 absolute path identifying the file.
+        Returns:
+         Nothing.
+        """
+        _do_rm_file(self._iso, iso_path)
+
+    def add_fp(self, fp, length, iso_path, joliet_path=None, file_mode=None):
+        # type: (BinaryIO, int, str, Optional[str], Optional[int]) -> None
+        """
+        Add a new file to the ISO in place, reading the content from
+        a file-like object.
+
+        The new file's data extent is appended to the end of the ISO
+        (the underlying file on disk grows by the rounded-up content
+        length).  The directory record is inserted into the parent's
+        existing extent on disk.
+
+        Constraints:
+         - The ISO must not be a UDF, Rock Ridge, or El Torito ISO
+           (out of scope for v1).
+         - The target's parent directory must already exist on the ISO.
+         - The parent's directory extent must have enough slack to
+           hold one more record; if not, this raises and you must use
+           :meth:`pycdlib.PyCdlib.add_fp` + ``write_fp`` instead.
+         - The caller is responsible for keeping ``fp`` open for the
+           lifetime of this editor (until the with-block exits).
+
+        Parameters:
+         fp - A file-like object containing the new file's content.
+         length - The length of the new content.
+         iso_path - The ISO9660 absolute path identifying where to
+                    insert the file.
+         joliet_path - The Joliet absolute path; if provided, a Joliet
+                       directory record is also inserted.
+         file_mode - File-mode bits (ignored on non-Rock-Ridge ISOs;
+                     since v1 refuses Rock Ridge, this is informational).
+        Returns:
+         Nothing.
+        """
+        _do_add_fp(self._iso, fp, length, False, iso_path,
+                   joliet_path=joliet_path, file_mode=file_mode)
+
+    def add_file(self, filename, iso_path, joliet_path=None, file_mode=None):
+        # type: (str, str, Optional[str], Optional[int]) -> None
+        """
+        Add a new file to the ISO in place, reading the content from
+        a file on the local filesystem.
+
+        Same semantics and constraints as :meth:`add_fp` except that
+        pycdlib opens and closes ``filename`` itself, the same way
+        :meth:`pycdlib.PyCdlib.add_file` does relative to
+        :meth:`pycdlib.PyCdlib.add_fp`.
+
+        Parameters:
+         filename - The local filename whose content becomes the new
+                    file's content on the ISO.
+         iso_path - The ISO9660 absolute path identifying where to
+                    insert the file.
+         joliet_path - The Joliet absolute path; if provided, a Joliet
+                       directory record is also inserted.
+         file_mode - File-mode bits (ignored on non-Rock-Ridge ISOs).
+        Returns:
+         Nothing.
+        """
+        import os  # pylint: disable=import-outside-toplevel
+        _do_add_fp(self._iso, filename, os.stat(filename).st_size, True,
+                   iso_path, joliet_path=joliet_path, file_mode=file_mode)

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -4807,6 +4807,13 @@ class PyCdlib:
                 while node is not None and id(node) not in rewritten_parents:
                     rewritten_parents.add(id(node))
                     self._rewrite_dir_record_extent(node)
+                    # Each subdirectory of `node` has a dotdot record
+                    # (in its own extent) whose data_length carries
+                    # node.data_length.  _add_child / _remove_child
+                    # keep those dotdots in sync in memory, but the
+                    # bytes on disk haven't been touched unless we
+                    # rewrite them here.
+                    self._rewrite_subdir_dotdots(node)
                     node = node.parent
             elif isinstance(record, udfmod.UDFFileEntry):
                 record.set_data_length(length)
@@ -4869,6 +4876,45 @@ class PyCdlib:
         if last_byte < end_byte:
             self._cdfp.seek(last_byte)
             self._cdfp.write(b'\x00' * (end_byte - last_byte))
+
+    def _rewrite_subdir_dotdots(self, parent):
+        # type: (dr.DirectoryRecord) -> None
+        """
+        Patch each subdirectory of `parent` so its on-disk dotdot
+        record matches the in-memory dotdot.  Each subdirectory's
+        dotdot record carries `parent.data_length` (the "size of the
+        parent's directory data extent" field per ISO9660); when
+        `_remove_child`'s underflow handler or `_add_child`'s overflow
+        handler changes parent.data_length, it updates each
+        subdirectory's in-memory dotdot to match -- but those dotdot
+        records live in their respective subdirectories' own extents
+        on disk, which `modify_file_in_place` does not otherwise
+        rewrite.  Without this writeback the on-disk dotdots claim a
+        stale parent data_length.  Real parsers don't use the field
+        for navigation (they follow dotdot.extent_location and bound
+        reads via the grandparent's record of the parent), but the
+        on-disk state is spec-inconsistent.
+
+        Idempotent: subdirectories whose in-memory dotdot already
+        matches the on-disk bytes get the same bytes written back.
+
+        Parameters:
+         parent - The DirectoryRecord whose subdirectories' dotdot
+                  records should be brought up to date on disk.
+        Returns:
+         Nothing.
+        """
+        lbs = self.logical_block_size
+        for subdir in parent._subdir_children:
+            if len(subdir.children) < 2:
+                continue
+            dot = subdir.children[0]
+            dotdot = subdir.children[1]
+            # dotdot lives at offset dot.dr_len within subdir's first
+            # extent (it is always the second record, right after dot).
+            offset = subdir.extent_location() * lbs + dot.dr_len
+            self._cdfp.seek(offset)
+            self._cdfp.write(dotdot.record())
 
     def add_hard_link(self, **kwargs):
         # type: (...) -> None

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -25,6 +25,7 @@ import os
 import struct
 import sys
 import time
+import warnings
 
 from pycdlib import dr
 from pycdlib import eltorito
@@ -4512,6 +4513,9 @@ class PyCdlib:
         Returns:
          Nothing.
         """
+        warnings.warn('get_and_write is deprecated; use get_file_from_iso instead.',
+                      DeprecationWarning, stacklevel=2)
+
         if not self._initialized:
             raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
 
@@ -4536,6 +4540,9 @@ class PyCdlib:
         Returns:
          Nothing.
         """
+        warnings.warn('get_and_write_fp is deprecated; use get_file_from_iso_fp instead.',
+                      DeprecationWarning, stacklevel=2)
+
         if not self._initialized:
             raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
 
@@ -5295,6 +5302,8 @@ class PyCdlib:
         Returns:
          Nothing.
         """
+        warnings.warn("add_joliet_directory is deprecated; use add_directory(joliet_path=...) instead.",
+                      DeprecationWarning, stacklevel=2)
         self.add_directory(joliet_path=joliet_path)
 
     def rm_file(self, iso_path=None, rr_name=None, joliet_path=None,  # pylint: disable=unused-argument
@@ -5466,6 +5475,8 @@ class PyCdlib:
         Returns:
          Nothing.
         """
+        warnings.warn("rm_joliet_directory is deprecated; use rm_directory(joliet_path=...) instead.",
+                      DeprecationWarning, stacklevel=2)
         self.rm_directory(joliet_path=joliet_path)
 
     def add_eltorito(self, bootfile_path, bootcatfile=None,
@@ -5872,6 +5883,9 @@ class PyCdlib:
         Returns:
          Nothing.
         """
+        warnings.warn('list_dir is deprecated; use list_children instead.',
+                      DeprecationWarning, stacklevel=2)
+
         if not self._initialized:
             raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
 
@@ -5956,6 +5970,9 @@ class PyCdlib:
         Returns:
          A dr.DirectoryRecord object representing the path.
         """
+        warnings.warn('get_entry is deprecated; use get_record instead.',
+                      DeprecationWarning, stacklevel=2)
+
         if not self._initialized:
             raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
 

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -4680,28 +4680,19 @@ class PyCdlib:
 
         self._finish_add(0, num_bytes_to_add)
 
-    def modify_file_in_place(self, fp, length, iso_path, rr_name=None,  # pylint: disable=unused-argument
-                             joliet_path=None, udf_path=None):          # pylint: disable=unused-argument
+    def modify_file_in_place(self, fp, length, iso_path, rr_name=None,
+                             joliet_path=None, udf_path=None):
         # type: (BinaryIO, int, str, Optional[str], Optional[str], Optional[str]) -> None
         """
-        An API to modify a file in place on the ISO.  This can be extremely fast
-        (much faster than calling the write method), but has many restrictions.
+        Modify a file in place on the ISO.
 
-        1.  The original ISO file pointer must have been opened for reading
-            and writing.
-        2.  Only an existing *file* can be modified; directories cannot be
-            changed.
-        3.  Only an existing file can be *modified*; no new files can be added
-            or removed.
-        4.  The new file contents must use the same number of extents (typically
-            2048 bytes) as the old file contents.  If using this API to shrink
-            a file, this is usually easy since the new contents can be padded
-            out with zeros or newlines to meet the requirement.  If using this
-            API to grow a file, the new contents can only grow up to the next
-            extent boundary.
-
-        Unlike all other APIs in PyCdlib, this API actually modifies the
-        originally opened on-disk file, so use it with caution.
+        .. deprecated::
+           Use :class:`pycdlib.InPlaceEditor` (a context manager)
+           instead.  It exposes the same in-place primitive but lives
+           on a focused class that intentionally does not surface
+           PyCdlib's mastering APIs, eliminating the silent
+           disk-corruption failure mode that arises when in-place edits
+           are mixed with ``add_*`` / ``rm_*`` / ``write_fp``.
 
         Parameters:
          fp - The file object to use for the contents of the new file.
@@ -4713,123 +4704,17 @@ class PyCdlib:
         Returns:
          Nothing.
         """
-        if not self._initialized:
-            raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
-
-        if hasattr(self._cdfp, 'mode') and not self._cdfp.mode.startswith(('r+', 'w', 'a', 'rb+')):
-            raise pycdlibexception.PyCdlibInvalidInput('To modify a file in place, the original ISO must have been opened in a write mode (r+, w, or a)')
-
-        child = self._find_iso_record(utils.normpath(iso_path))
-
-        old_num_extents = utils.ceiling_div(child.get_data_length(),
-                                            self.logical_block_size)
-        new_num_extents = utils.ceiling_div(length, self.logical_block_size)
-
-        if old_num_extents != new_num_extents:
-            raise pycdlibexception.PyCdlibInvalidInput('When modifying a file in-place, the number of extents for a file cannot change!')
-
-        if not child.is_file():
-            raise pycdlibexception.PyCdlibInvalidInput('Cannot modify a directory with modify_file_in_place')
-
-        if child.inode is None:
-            raise pycdlibexception.PyCdlibInternalError('Child file found without inode')
-
-        child.inode.update_fp(fp, length)
-
-        # Remove the old size from the PVD size.
-        for pvd in self.pvds:
-            pvd.remove_from_space_size(child.get_data_length())
-        # And add the new size to the PVD size.
-        for pvd in self.pvds:
-            pvd.add_to_space_size(length)
-
-        if self.enhanced_vd is not None:
-            self.enhanced_vd.copy_sizes(self.pvd)
-
-        # If we made it here, we have successfully updated all of the in-memory
-        # metadata.  Now we can go and modify the on-disk file.
-
-        self._seek_to_extent(self.pvd.extent_location())
-
-        # First write out the PVD.
-        rec = self.pvd.record()
-        self._cdfp.write(rec)
-
-        # Write out the joliet VD.
-        if self.joliet_vd is not None:
-            self._seek_to_extent(self.joliet_vd.extent_location())
-            rec = self.joliet_vd.record()
-            self._cdfp.write(rec)
-
-        # Write out the enhanced VD.
-        if self.enhanced_vd is not None:
-            self._seek_to_extent(self.enhanced_vd.extent_location())
-            rec = self.enhanced_vd.record()
-            self._cdfp.write(rec)
-
-        # We don't have to write anything out for UDF since it only tracks
-        # extents, and we know we aren't changing the number of extents.
-
-        # Write out the actual file contents.
-        self._seek_to_extent(child.extent_location())
-        with inode.InodeOpenData(child.inode, self.logical_block_size) as (data_fp, data_len):
-            utils.copy_data(data_len, self.logical_block_size, data_fp, self._cdfp)
-            utils.zero_pad(self._cdfp, data_len, self.logical_block_size)
-
-        # Finally update the directory record entries that reference this
-        # file with the new length.  For UDF the file entry has its own
-        # extent, so we can write it directly.  For ISO9660/Joliet the
-        # record lives inside its parent's directory extent; we used to
-        # compute that record's byte offset from extents_to_here /
-        # offset_to_here (which reflect pycdlib's in-memory sorted order
-        # of children), but the on-disk order doesn't always match the
-        # sorted order -- writing to the computed offset then corrupts
-        # whichever sibling actually sits at that on-disk position
-        # (issue #122).  Rewrite the parent's full child list instead.
-        first_joliet = True
-        rewritten_parents = set()  # type: set
-        for record, is_pvd_unused in child.inode.linked_records:
-            if isinstance(record, dr.DirectoryRecord):
-                if self.joliet_vd is not None and id(record.vd) == id(self.joliet_vd) and first_joliet:
-                    first_joliet = False
-                    self.joliet_vd.remove_from_space_size(record.get_data_length())
-                    self.joliet_vd.add_to_space_size(length)
-                if record.parent is None:
-                    raise pycdlibexception.PyCdlibInternalError('Modifying file with empty parent')
-                record.set_data_length(length)
-                # Walk up the parent chain, rewriting each ancestor's
-                # extent.  The immediate parent's rewrite captures the
-                # modified file's new data_length; each higher
-                # ancestor's rewrite captures the data_length of its
-                # child (which may have shrunk via _remove_child's
-                # underflow handler when a sibling was removed).
-                # Without the up-walk, an in-memory data_length change
-                # never reaches the on-disk record that the parser
-                # uses to bound the data extent, and the parser reads
-                # stale bytes from a dropped extent.  We stop at the
-                # root: the root's data_length lives in the PVD's
-                # root_directory_record, which is already written out
-                # earlier in modify_file_in_place.
-                node = record.parent
-                while node is not None and id(node) not in rewritten_parents:
-                    rewritten_parents.add(id(node))
-                    self._rewrite_dir_record_extent(node)
-                    # Each subdirectory of `node` has a dotdot record
-                    # (in its own extent) whose data_length carries
-                    # node.data_length.  _add_child / _remove_child
-                    # keep those dotdots in sync in memory, but the
-                    # bytes on disk haven't been touched unless we
-                    # rewrite them here.
-                    self._rewrite_subdir_dotdots(node)
-                    node = node.parent
-            elif isinstance(record, udfmod.UDFFileEntry):
-                record.set_data_length(length)
-                abs_offset = record.extent_location() * self.logical_block_size
-                self._cdfp.seek(abs_offset)
-                self._cdfp.write(record.record())
-            else:
-                # This should never happen
-                raise pycdlibexception.PyCdlibInternalError('Invalid record type')
+        warnings.warn(
+            'PyCdlib.modify_file_in_place is deprecated; use '
+            'pycdlib.InPlaceEditor (context manager) instead.',
+            DeprecationWarning, stacklevel=2)
+        # Local import to avoid a circular import at module load time:
+        # inplaceeditor.py imports PyCdlib from this module.
+        from pycdlib.inplaceeditor import _do_modify_file_in_place  # pylint: disable=import-outside-toplevel
+        _do_modify_file_in_place(self, fp, length, iso_path,
+                                 rr_name=rr_name,
+                                 joliet_path=joliet_path,
+                                 udf_path=udf_path)
 
     def _rewrite_dir_record_extent(self, parent):
         # type: (dr.DirectoryRecord) -> None

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -4811,22 +4811,50 @@ class PyCdlib:
         to avoid relying on per-record offsets that may be wrong if the
         on-disk order doesn't match pycdlib's sorted order (issue #122).
 
+        This function owns the bytes from the start of the parent's
+        first extent through parent.data_length.  Any byte in that
+        range that the new in-memory layout does not cover with a
+        record is zero-padded so that the on-disk parser (which expects
+        either a directory record or a zero byte followed by all-zero
+        padding to the end of the data block) does not fall off the
+        rails on stale bytes from a previous on-disk layout.
+
         Parameters:
          parent - The parent DirectoryRecord whose children should be
                   written out to disk.
         Returns:
          Nothing.
         """
-        dir_extent = parent.extent_location()
+        lbs = self.logical_block_size
+        first_extent = parent.extent_location()
+        dir_extent = first_extent
         offset_in_extent = 0
         for ch in parent.children:
             recstr = ch.record()
-            if offset_in_extent + len(recstr) > self.logical_block_size:
+            if offset_in_extent + len(recstr) > lbs:
+                # The next record won't fit in the current extent.
+                # Zero-pad the rest of this extent before advancing,
+                # so any stale bytes from a prior on-disk layout are
+                # cleared.
+                self._cdfp.seek(dir_extent * lbs + offset_in_extent)
+                self._cdfp.write(b'\x00' * (lbs - offset_in_extent))
                 dir_extent += 1
                 offset_in_extent = 0
-            self._cdfp.seek(dir_extent * self.logical_block_size + offset_in_extent)
+            self._cdfp.seek(dir_extent * lbs + offset_in_extent)
             self._cdfp.write(recstr)
             offset_in_extent += len(recstr)
+
+        # Zero-pad from the end of the last record through the end of
+        # parent.data_length.  data_length tracks the in-memory extent
+        # span (the writer maintains it through _add_child overflow and
+        # remove_child underflow); the on-disk parser will read up to
+        # this many bytes, so every byte in that range must be either a
+        # valid record or part of the zero-padding tail.
+        last_byte = dir_extent * lbs + offset_in_extent
+        end_byte = first_extent * lbs + parent.data_length
+        if last_byte < end_byte:
+            self._cdfp.seek(last_byte)
+            self._cdfp.write(b'\x00' * (end_byte - last_byte))
 
     def add_hard_link(self, **kwargs):
         # type: (...) -> None

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -4923,6 +4923,138 @@ class PyCdlib:
             self._cdfp.seek(offset)
             self._cdfp.write(dotdot.record())
 
+    def _update_file_contents(self, fp, length, manage_fp, iso_path, rr_path,
+                              joliet_path, udf_path):
+        # type: (Union[BinaryIO, str], int, bool, Optional[str], Optional[str], Optional[str], Optional[str]) -> None
+        """
+        Internal helper backing `update_file_contents_fp` and
+        `update_file_contents`.  Resolves the target file via exactly
+        one of the supplied paths, swaps the shared Inode's data
+        source, propagates the new length to every linked record, and
+        adjusts PVD/Joliet/UDF size accounting.  All disk writes are
+        deferred to the next `write_fp()` call.
+        """
+        if not self._initialized:
+            raise pycdlibexception.PyCdlibInvalidInput('This object is not initialized; call either open() or new() to create an ISO')
+
+        num_paths = sum(p is not None for p in (iso_path, rr_path, joliet_path, udf_path))
+        if num_paths != 1:
+            raise pycdlibexception.PyCdlibInvalidInput("Exactly one of 'iso_path', 'rr_path', 'joliet_path', or 'udf_path' must be provided")
+
+        # Resolve to the target's shared Inode via whichever path was given.
+        if udf_path is not None:
+            if self.udf_root is None:
+                raise pycdlibexception.PyCdlibInvalidInput('Cannot use udf_path on a non-UDF ISO')
+            _, file_entry = self._find_udf_record(utils.normpath(udf_path))
+            if file_entry is None or not file_entry.is_file():
+                raise pycdlibexception.PyCdlibInvalidInput('Cannot update the contents of a directory or empty UDF entry')
+            ino = file_entry.inode
+        else:
+            if iso_path is not None:
+                record = self._find_iso_record(utils.normpath(iso_path))
+            elif rr_path is not None:
+                if not self.rock_ridge:
+                    raise pycdlibexception.PyCdlibInvalidInput('Cannot use rr_path on a non-Rock-Ridge ISO')
+                record = self._find_rr_record(utils.normpath(rr_path))
+            elif joliet_path is not None:
+                record = self._find_joliet_record(self._normalize_joliet_path(joliet_path))
+            else:
+                raise pycdlibexception.PyCdlibInternalError('No identifying path provided for update_file_contents')
+            if not record.is_file():
+                raise pycdlibexception.PyCdlibInvalidInput('Cannot update the contents of a directory')
+            if record.is_symlink():
+                raise pycdlibexception.PyCdlibInvalidInput('Cannot update the contents of a symlink')
+            ino = record.inode
+
+        if ino is None:
+            raise pycdlibexception.PyCdlibInternalError('File found without an inode')
+
+        old_length = ino.data_length
+
+        # Swap the inode's data source.  Every linked record reads through
+        # this inode, so they all see the new content on the next write_fp().
+        ino.update_fp(fp, length, manage_fp=manage_fp)
+
+        # Propagate the new length to every linked DirectoryRecord and UDF
+        # File Entry so its serialized record reflects the right size when
+        # write_fp() runs.  El Torito entries don't go through set_data_length;
+        # if a file is both an El Torito boot image and a regular file, the
+        # El Torito side picks up the new size automatically via the shared
+        # Inode's data_length.
+        for record_obj, _is_pvd in ino.linked_records:
+            if isinstance(record_obj, (dr.DirectoryRecord, udfmod.UDFFileEntry)):
+                record_obj.set_data_length(length)
+
+        # Adjust PVD / Joliet / UDF size accounting via the existing helpers.
+        # These set _needs_reshuffle so the next write_fp() recomputes the
+        # layout cleanly.
+        self._finish_remove(old_length, is_partition=True)
+        self._finish_add(0, length)
+
+    def update_file_contents_fp(self, fp, length, iso_path=None, rr_path=None,
+                                joliet_path=None, udf_path=None):
+        # type: (BinaryIO, int, Optional[str], Optional[str], Optional[str], Optional[str]) -> None
+        """
+        Replace the contents of an existing file on the ISO with new
+        content read from `fp`, deferring all disk writes to the next
+        `write_fp()` call.
+
+        Exactly one of `iso_path`, `rr_path`, `joliet_path`, or
+        `udf_path` must be provided to identify the target file.  The
+        update propagates to every linked record (ISO9660 / Joliet /
+        UDF) automatically because they share the same Inode.
+
+        The caller is responsible for keeping `fp` open for the
+        lifetime of this PyCdlib object (until close() runs), the same
+        way `add_fp()` requires.
+
+        Parameters:
+         fp - A file-like object containing the new contents.
+         length - The length of the new contents.
+         iso_path - The ISO9660 absolute path to the file destination on
+                    the ISO.
+         rr_path - The Rock Ridge absolute path to the file destination
+                   on the ISO.
+         joliet_path - The Joliet absolute path to the file destination
+                       on the ISO.
+         udf_path - The UDF absolute path to the file destination on the
+                    ISO.
+        Returns:
+         Nothing.
+        """
+        self._update_file_contents(fp, length, False, iso_path, rr_path,
+                                   joliet_path, udf_path)
+
+    def update_file_contents(self, filename, iso_path=None, rr_path=None,
+                             joliet_path=None, udf_path=None):
+        # type: (str, Optional[str], Optional[str], Optional[str], Optional[str]) -> None
+        """
+        Replace the contents of an existing file on the ISO with the
+        contents of `filename` on the local filesystem, deferring all
+        disk writes to the next `write_fp()` call.
+
+        Same semantics as `update_file_contents_fp` except that
+        pycdlib opens `filename` and manages its lifetime, the same
+        way `add_file()` does relative to `add_fp()`.  The file is
+        closed when the PyCdlib object is closed.
+
+        Parameters:
+         filename - The local filename whose contents replace the
+                    target file's contents.
+         iso_path - The ISO9660 absolute path to the file destination on
+                    the ISO.
+         rr_path - The Rock Ridge absolute path to the file destination
+                   on the ISO.
+         joliet_path - The Joliet absolute path to the file destination
+                       on the ISO.
+         udf_path - The UDF absolute path to the file destination on the
+                    ISO.
+        Returns:
+         Nothing.
+        """
+        self._update_file_contents(filename, os.stat(filename).st_size, True,
+                                   iso_path, rr_path, joliet_path, udf_path)
+
     def add_hard_link(self, **kwargs):
         # type: (...) -> None
         """

--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -4790,10 +4790,24 @@ class PyCdlib:
                 if record.parent is None:
                     raise pycdlibexception.PyCdlibInternalError('Modifying file with empty parent')
                 record.set_data_length(length)
-                parent_id = id(record.parent)
-                if parent_id not in rewritten_parents:
-                    rewritten_parents.add(parent_id)
-                    self._rewrite_dir_record_extent(record.parent)
+                # Walk up the parent chain, rewriting each ancestor's
+                # extent.  The immediate parent's rewrite captures the
+                # modified file's new data_length; each higher
+                # ancestor's rewrite captures the data_length of its
+                # child (which may have shrunk via _remove_child's
+                # underflow handler when a sibling was removed).
+                # Without the up-walk, an in-memory data_length change
+                # never reaches the on-disk record that the parser
+                # uses to bound the data extent, and the parser reads
+                # stale bytes from a dropped extent.  We stop at the
+                # root: the root's data_length lives in the PVD's
+                # root_directory_record, which is already written out
+                # earlier in modify_file_in_place.
+                node = record.parent
+                while node is not None and id(node) not in rewritten_parents:
+                    rewritten_parents.add(id(node))
+                    self._rewrite_dir_record_extent(node)
+                    node = node.parent
             elif isinstance(record, udfmod.UDFFileEntry):
                 record.set_data_length(length)
                 abs_offset = record.extent_location() * self.logical_block_size

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,21 @@
+import re
+
 import pytest
+
+
+def uses_deprecated(*api_names):
+    """Mark a test as a caller of one or more deprecated APIs.
+
+    Silences the DeprecationWarning that those APIs emit, and leaves
+    the API name(s) as a literal grep target in the test source.  When
+    a deprecated API is finally removed, grep tests/ for its name to
+    find every test still on the old code path.
+    """
+    pattern = '|'.join(re.escape(name) for name in api_names)
+    return pytest.mark.filterwarnings(
+        rf'ignore:.*({pattern}) is deprecated:DeprecationWarning'
+    )
+
 
 def pytest_addoption(parser):
     parser.addoption('--runslow', action='store_true',

--- a/tests/integration/test_common.py
+++ b/tests/integration/test_common.py
@@ -8,8 +8,13 @@ import struct
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+# Also expose tests/ so we can pull shared test helpers out of
+# tests/conftest.py via a normal `from conftest import ...`.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pycdlib
+
+from conftest import uses_deprecated  # re-exported for `from test_common import *`
 
 # Technically, Rock Ridge doesn't impose a length limitation on NM (alternate
 # name) or SL (symlinks).  However, in practice, the Linux kernel (at least

--- a/tests/integration/test_hybrid.py
+++ b/tests/integration/test_hybrid.py
@@ -2798,6 +2798,7 @@ def test_hybrid_rr_hidden_relocated(tmpdir):
 
     iso.close()
 
+@uses_deprecated("list_dir")
 def test_hybrid_rr_relocated_list_dir(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('rrdeeplistdir')

--- a/tests/integration/test_hybrid.py
+++ b/tests/integration/test_hybrid.py
@@ -2264,7 +2264,7 @@ def test_hybrid_modify_in_place_grow_file(tmpdir):
     foostr = b'f'*2049
     with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
         iso.modify_file_in_place(io.BytesIO(foostr), len(foostr), '/foo')
-    assert(str(excinfo.value) == 'When modifying a file in-place, the number of extents for a file cannot change!')
+    assert(str(excinfo.value) == 'When modifying a file in-place, the number of extents for a file cannot grow!')
 
     iso.close()
 

--- a/tests/integration/test_hybrid.py
+++ b/tests/integration/test_hybrid.py
@@ -1829,12 +1829,10 @@ def test_hybrid_modify_in_place_onefile(tmpdir):
     subprocess.call(['genisoimage', '-v', '-v', '-iso-level', '1', '-no-pad',
                      '-o', str(outfile), str(indir)])
 
-    # Now open up the ISO with pycdlib and modify it.
-    iso = pycdlib.PyCdlib()
-    iso.open(str(outfile), 'r+b')
+    # Now modify it in place via the editor context manager.
     foostr = b'foo\n'
-    iso.modify_file_in_place(io.BytesIO(foostr), len(foostr), '/FOO.;1')
-    iso.close()
+    with pycdlib.InPlaceEditor(str(outfile)) as ed:
+        ed.modify_file(io.BytesIO(foostr), len(foostr), '/FOO.;1')
 
     # Now re-open it and check things out.
     open_and_check(outfile, check_onefile)
@@ -1848,12 +1846,10 @@ def test_hybrid_joliet_modify_in_place_onefile(tmpdir):
     subprocess.call(['genisoimage', '-v', '-v', '-iso-level', '1', '-no-pad',
                      '-J', '-o', str(outfile), str(indir)])
 
-    # Now open up the ISO with pycdlib and modify it.
-    iso = pycdlib.PyCdlib()
-    iso.open(str(outfile), 'r+b')
+    # Now modify it in place via the editor context manager.
     foostr = b'foo\n'
-    iso.modify_file_in_place(io.BytesIO(foostr), len(foostr), '/FOO.;1', joliet_path='/foo')
-    iso.close()
+    with pycdlib.InPlaceEditor(str(outfile)) as ed:
+        ed.modify_file(io.BytesIO(foostr), len(foostr), '/FOO.;1', joliet_path='/foo')
 
     # Now re-open it and check things out.
     open_and_check(outfile, check_joliet_onefile)
@@ -1867,14 +1863,11 @@ def test_hybrid_modify_in_place_iso_level4_onefile(tmpdir):
     subprocess.call(['genisoimage', '-v', '-v', '-iso-level', '4', '-no-pad',
                      '-o', str(outfile), str(indir)])
 
-    # Now open up the ISO with pycdlib and check some things out.
-    iso = pycdlib.PyCdlib()
-    iso.open(str(outfile), 'r+b')
+    # Now modify it in place via the editor context manager.
     foostr = b'foo\n'
-    iso.modify_file_in_place(io.BytesIO(foostr), len(foostr), '/foo')
-    iso.close()
+    with pycdlib.InPlaceEditor(str(outfile)) as ed:
+        ed.modify_file(io.BytesIO(foostr), len(foostr), '/foo')
 
-    # Now open up the ISO with pycdlib and modify it.
     open_and_check(outfile, check_isolevel4_onefile)
 
 def test_hybrid_modify_in_place_udf(tmpdir):
@@ -1886,14 +1879,11 @@ def test_hybrid_modify_in_place_udf(tmpdir):
     subprocess.call(['genisoimage', '-v', '-v', '-iso-level', '1', '-no-pad',
                      '-udf', '-o', str(outfile), str(indir)])
 
-    # Now open up the ISO with pycdlib and check some things out.
-    iso = pycdlib.PyCdlib()
-    iso.open(str(outfile), 'r+b')
+    # Now modify it in place via the editor context manager.
     foostr = b'foo\n'
-    iso.modify_file_in_place(io.BytesIO(foostr), len(foostr), '/FOO.;1')
-    iso.close()
+    with pycdlib.InPlaceEditor(str(outfile)) as ed:
+        ed.modify_file(io.BytesIO(foostr), len(foostr), '/FOO.;1')
 
-    # Now open up the ISO with pycdlib and modify it.
     open_and_check(outfile, check_udf_onefile)
 
 def test_hybrid_modify_in_place_udf_shrink(tmpdir):
@@ -1905,14 +1895,11 @@ def test_hybrid_modify_in_place_udf_shrink(tmpdir):
     subprocess.call(['genisoimage', '-v', '-v', '-iso-level', '1', '-no-pad',
                      '-udf', '-o', str(outfile), str(indir)])
 
-    # Now open up the ISO with pycdlib and check some things out.
-    iso = pycdlib.PyCdlib()
-    iso.open(str(outfile), 'r+b')
+    # Now modify it in place via the editor context manager.
     foostr = b'foo\n'
-    iso.modify_file_in_place(io.BytesIO(foostr), len(foostr), '/FOO.;1')
-    iso.close()
+    with pycdlib.InPlaceEditor(str(outfile)) as ed:
+        ed.modify_file(io.BytesIO(foostr), len(foostr), '/FOO.;1')
 
-    # Now open up the ISO with pycdlib and modify it.
     open_and_check(outfile, check_udf_onefile)
 
 def test_hybrid_try_to_use_new_on_open_file(tmpdir):
@@ -1951,6 +1938,7 @@ def test_hybrid_try_to_use_open_on_new_file(tmpdir):
 
     iso.close()
 
+@uses_deprecated("modify_file_in_place")
 def test_hybrid_modify_in_place_not_initialized(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('modifyinplaceonefile')
@@ -1968,6 +1956,7 @@ def test_hybrid_modify_in_place_not_initialized(tmpdir):
         iso.modify_file_in_place(io.BytesIO(foostr), len(foostr), '/FOO.;1', rr_name='foo', joliet_path='/foo')
     assert(str(excinfo.value) == 'This object is not initialized; call either open() or new() to create an ISO')
 
+@uses_deprecated("modify_file_in_place")
 def test_hybrid_modify_in_place_read_only(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('modifyinplaceonefile')
@@ -2235,6 +2224,7 @@ def test_hybrid_addfile_not_initialized(tmpdir):
         iso.add_fp(io.BytesIO(foostr), len(foostr), '/FOO.;1')
     assert(str(excinfo.value) == 'This object is not initialized; call either open() or new() to create an ISO')
 
+@uses_deprecated("modify_file_in_place")
 def test_hybrid_modify_in_place_bad_path(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('modifyinplaceisolevel4onefile')
@@ -2256,6 +2246,7 @@ def test_hybrid_modify_in_place_bad_path(tmpdir):
 
     iso.close()
 
+@uses_deprecated("modify_file_in_place")
 def test_hybrid_modify_in_place_grow_file(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('modifyinplaceisolevel4onefile')
@@ -2277,6 +2268,7 @@ def test_hybrid_modify_in_place_grow_file(tmpdir):
 
     iso.close()
 
+@uses_deprecated("modify_file_in_place")
 def test_hybrid_modify_in_place_modify_dir(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('modifyinplaceisolevel4onefile')
@@ -2396,14 +2388,11 @@ def test_hybrid_modify_in_place_dirrecord_spillover(tmpdir):
     subprocess.call(['genisoimage', '-v', '-v', '-iso-level', '1', '-no-pad',
                      '-o', str(outfile), str(indir)])
 
-    # Now open up the ISO with pycdlib and check some things out.
-    iso = pycdlib.PyCdlib()
-    iso.open(str(outfile), 'r+b')
+    # Now modify it in place via the editor context manager.
     foostr = b'foo\n'
-    iso.modify_file_in_place(io.BytesIO(foostr), len(foostr), '/DIR1/FOO48.;1')
-    iso.close()
+    with pycdlib.InPlaceEditor(str(outfile)) as ed:
+        ed.modify_file(io.BytesIO(foostr), len(foostr), '/DIR1/FOO48.;1')
 
-    # Now open up the ISO with pycdlib and modify it.
     open_and_check(outfile, check_modify_in_place_spillover)
 
 def test_hybrid_modify_in_place_dirrecord_spillover2(tmpdir):
@@ -2418,14 +2407,11 @@ def test_hybrid_modify_in_place_dirrecord_spillover2(tmpdir):
     subprocess.call(['genisoimage', '-v', '-v', '-iso-level', '1', '-no-pad',
                      '-o', str(outfile), str(indir)])
 
-    # Now open up the ISO with pycdlib and check some things out.
-    iso = pycdlib.PyCdlib()
-    iso.open(str(outfile), 'r+b')
+    # Now modify it in place via the editor context manager.
     foostr = b'foo\n'
-    iso.modify_file_in_place(io.BytesIO(foostr), len(foostr), '/DIR1/FOO40.;1')
-    iso.close()
+    with pycdlib.InPlaceEditor(str(outfile)) as ed:
+        ed.modify_file(io.BytesIO(foostr), len(foostr), '/DIR1/FOO40.;1')
 
-    # Now open up the ISO with pycdlib and modify it.
     open_and_check(outfile, check_modify_in_place_spillover)
 
 def test_hybrid_shuffle_deep(tmpdir):

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2771,6 +2771,75 @@ def test_new_rewrite_dir_record_extent_pads_across_extent_transition():
     assert buf.getvalue() == b'aaa\n'
     iso3.close()
 
+def test_new_modify_file_in_place_rewrites_grandparent_after_underflow():
+    # When rm_file shrinks a parent's data_length via _remove_child's
+    # underflow handler, the parent's on-disk directory record (stored
+    # in the grandparent's extent) still has the original, larger
+    # data_length.  Without the grandparent rewrite,
+    # modify_file_in_place updates the parent's extent but leaves the
+    # grandparent's record for the parent stale.  When the ISO is
+    # re-parsed, the parser walks the parent's data using the stale
+    # on-disk data_length and reads past the new in-memory layout into
+    # the dropped extent's stale bytes, producing phantom records or
+    # parse failures.
+    #
+    # Build a directory whose children span two extents, rm enough
+    # children to trigger underflow (parent.data_length shrinks from
+    # 2 extents to 1), modify a remaining sibling, and verify the
+    # re-parsed ISO reflects the shrunken span -- no phantom records.
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_directory('/DIR')
+    # 60 children at level-1 ISO9660 spans roughly two extents.
+    names = [f'F{i:03d}' for i in range(60)]
+    for name in names:
+        iso.add_fp(io.BytesIO((name + '\n').encode()), 5, f'/DIR/{name}.;1')
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    out.seek(0)
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+    dir_record = iso2._find_iso_record(b'/DIR')
+    original_dir_data_length = dir_record.data_length
+    assert original_dir_data_length > 2048
+    # Removing 50 children drops the in-memory total well below one
+    # extent, which fires _remove_child's underflow once and shrinks
+    # parent.data_length by logical_block_size.
+    for i in range(50):
+        iso2.rm_file(iso_path=f'/DIR/F{i:03d}.;1')
+    assert dir_record.data_length < original_dir_data_length
+    # Modifying a remaining sibling exercises modify_file_in_place's
+    # rewrite of parent (and now grandparent) extents on disk.
+    iso2.modify_file_in_place(io.BytesIO(b'aaa\n'), 4, '/DIR/F059.;1')
+    iso2.close()
+
+    iso3 = pycdlib.PyCdlib()
+    iso3.open_fp(out)
+    dir_record3 = iso3._find_iso_record(b'/DIR')
+    # The on-disk data_length for /DIR (read from root's extent) must
+    # reflect the shrunken in-memory value.  Without the fix, this
+    # still holds the original value and the parser reads stale bytes
+    # from the dropped extent.
+    assert dir_record3.data_length == dir_record.data_length
+    # Exactly the surviving 10 children should be visible.
+    remaining = [f'F{i:03d}' for i in range(50, 60)]
+    children = sorted(
+        ch.file_identifier()
+        for ch in dir_record3.children
+        if ch.file_identifier() not in (b'.', b'..')
+    )
+    assert children == sorted(f'{name}.;1'.encode() for name in remaining)
+    buf = io.BytesIO()
+    iso3.get_file_from_iso_fp(buf, iso_path='/DIR/F059.;1')
+    assert buf.getvalue() == b'aaa\n'
+    for name in ('F050', 'F055', 'F058'):
+        buf = io.BytesIO()
+        iso3.get_file_from_iso_fp(buf, iso_path=f'/DIR/{name}.;1')
+        assert buf.getvalue() == (name + '\n').encode()
+    iso3.close()
+
 def test_new_udf_boot_descriptor_parsed():
     # Coverage for the UDF BOOT2 (Boot Descriptor) dispatch in
     # _parse_volume_descriptors.  pycdlib's writer doesn't emit BOOT2 on

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2556,6 +2556,91 @@ def test_new_rr_onetwelve_missing_er_treated_as_non_rr():
     assert(not iso2.has_rock_ridge())
     iso2.close()
 
+def test_new_in_place_editor_modifies_file(tmpdir):
+    # The InPlaceEditor context manager opens an ISO, runs one or more
+    # in-place edits, and closes cleanly on exit.  The new content is
+    # readable from the same file after the with-block exits.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'old\n'), 4, '/FOO.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.modify_file(io.BytesIO(b'new\n'), 4, '/FOO.;1')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, iso_path='/FOO.;1')
+    assert buf.getvalue() == b'new\n'
+    iso2.close()
+
+def test_new_in_place_editor_multiple_modifies(tmpdir):
+    # The editor can batch multiple modifications in a single session,
+    # amortizing the parse cost.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'AAA\n'), 4, '/A.;1')
+    iso.add_fp(io.BytesIO(b'BBB\n'), 4, '/B.;1')
+    iso.add_fp(io.BytesIO(b'CCC\n'), 4, '/C.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.modify_file(io.BytesIO(b'aaa\n'), 4, '/A.;1')
+        ed.modify_file(io.BytesIO(b'bbb\n'), 4, '/B.;1')
+        ed.modify_file(io.BytesIO(b'ccc\n'), 4, '/C.;1')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    for path, expected in [('/A.;1', b'aaa\n'),
+                           ('/B.;1', b'bbb\n'),
+                           ('/C.;1', b'ccc\n')]:
+        buf = io.BytesIO()
+        iso2.get_file_from_iso_fp(buf, iso_path=path)
+        assert buf.getvalue() == expected
+    iso2.close()
+
+def test_new_in_place_editor_propagates_exceptions(tmpdir):
+    # If modify_file raises (e.g., bad iso_path), the editor still
+    # closes the underlying ISO via __exit__.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
+        with pycdlib.InPlaceEditor(iso_path) as ed:
+            ed.modify_file(io.BytesIO(b'x\n'), 2, '/NOPE.;1')
+
+def test_new_pycdlib_modify_file_in_place_warns(tmpdir):
+    # PyCdlib.modify_file_in_place is the deprecated method-on-class
+    # surface.  Verify it fires the DeprecationWarning that the
+    # standalone-function and InPlaceEditor migrations should drive
+    # users toward.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'old\n'), 4, '/FOO.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path, mode='rb+')
+    with pytest.warns(DeprecationWarning, match='modify_file_in_place is deprecated'):
+        iso2.modify_file_in_place(io.BytesIO(b'new\n'), 4, '/FOO.;1')
+    iso2.close()
+
+@uses_deprecated("modify_file_in_place")
 def test_new_modify_file_in_place_unsorted_dir_records():
     # Regression test for https://github.com/clalancette/pycdlib/issues/122.
     # modify_file_in_place used to compute the on-disk byte offset of a
@@ -2620,6 +2705,7 @@ def test_new_modify_file_in_place_unsorted_dir_records():
         assert(buf.getvalue() == expected)
     iso3.close()
 
+@uses_deprecated("modify_file_in_place")
 def test_new_rewrite_dir_record_extent_pads_after_rm():
     # Regression test for the zero-padding bug in
     # _rewrite_dir_record_extent.  Before the fix, the function wrote
@@ -2672,6 +2758,7 @@ def test_new_rewrite_dir_record_extent_pads_after_rm():
         assert(buf.getvalue() == expected)
     iso3.close()
 
+@uses_deprecated("modify_file_in_place")
 def test_new_rewrite_dir_record_extent_pads_after_rm_multi_extent():
     # Same as the previous test but with a parent directory whose
     # children span multiple extents.  The rm is small enough that the
@@ -2724,6 +2811,7 @@ def test_new_rewrite_dir_record_extent_pads_after_rm_multi_extent():
         assert buf.getvalue() == (name + '\n').encode()
     iso3.close()
 
+@uses_deprecated("modify_file_in_place")
 def test_new_rewrite_dir_record_extent_pads_across_extent_transition():
     # When _rewrite_dir_record_extent's serialized children pack
     # differently than the on-disk layout (e.g., because a child was
@@ -2771,6 +2859,7 @@ def test_new_rewrite_dir_record_extent_pads_across_extent_transition():
     assert buf.getvalue() == b'aaa\n'
     iso3.close()
 
+@uses_deprecated("modify_file_in_place")
 def test_new_modify_file_in_place_rewrites_grandparent_after_underflow():
     # When rm_file shrinks a parent's data_length via _remove_child's
     # underflow handler, the parent's on-disk directory record (stored
@@ -2840,6 +2929,7 @@ def test_new_modify_file_in_place_rewrites_grandparent_after_underflow():
         assert buf.getvalue() == (name + '\n').encode()
     iso3.close()
 
+@uses_deprecated("modify_file_in_place")
 def test_new_modify_file_in_place_rewrites_subdir_dotdots_after_underflow():
     # Companion to the grandparent rewrite test.  When _remove_child's
     # underflow handler shrinks parent.data_length, the in-memory

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2878,7 +2878,35 @@ def test_new_in_place_editor_add_fp_rejects_udf(tmpdir):
             ed.add_fp(io.BytesIO(b'new\n'), 4, '/NEW.;1')
         assert 'UDF' in str(excinfo.value)
 
-def test_new_in_place_editor_add_fp_rejects_rock_ridge(tmpdir):
+def test_new_in_place_editor_add_fp_rock_ridge_short_name(tmpdir):
+    # Rock Ridge ISOs are supported as long as the SUSP fields fit
+    # inside the directory record (i.e., no Continuation Entry block
+    # needs to be allocated).  Short rr_name values comfortably fit.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.09')
+    iso.add_fp(io.BytesIO(b'old\n'), 4, '/OLD.;1', rr_name='old')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.add_fp(io.BytesIO(b'new contents\n'), 13, '/NEW.;1', rr_name='new')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, iso_path='/NEW.;1')
+    assert buf.getvalue() == b'new contents\n'
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, rr_path='/new')
+    assert buf.getvalue() == b'new contents\n'
+    iso2.close()
+
+def test_new_in_place_editor_add_fp_rejects_rock_ridge_ce_required(tmpdir):
+    # When the rr_name is long enough to push the SUSP fields out of
+    # the directory record into a Continuation Entry block, in-place
+    # add can't allocate the CE storage and must refuse.
     iso_path = str(tmpdir.join('test.iso'))
     iso = pycdlib.PyCdlib()
     iso.new(rock_ridge='1.09')
@@ -2889,8 +2917,34 @@ def test_new_in_place_editor_add_fp_rejects_rock_ridge(tmpdir):
 
     with pycdlib.InPlaceEditor(iso_path) as ed:
         with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+            ed.add_fp(io.BytesIO(b'x'), 1, '/NEW.;1', rr_name='a' * 200)
+        assert 'Continuation Entry' in str(excinfo.value)
+
+def test_new_in_place_editor_add_fp_rock_ridge_requires_rr_name(tmpdir):
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.09')
+    iso.add_fp(io.BytesIO(b'old\n'), 4, '/OLD.;1', rr_name='old')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
             ed.add_fp(io.BytesIO(b'new\n'), 4, '/NEW.;1')
-        assert 'Rock Ridge' in str(excinfo.value)
+
+def test_new_in_place_editor_add_fp_rejects_rr_name_on_non_rock_ridge(tmpdir):
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'old\n'), 4, '/OLD.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
+            ed.add_fp(io.BytesIO(b'new\n'), 4, '/NEW.;1', rr_name='new')
 
 def test_new_in_place_editor_add_fp_rejects_eltorito(tmpdir):
     iso_path = str(tmpdir.join('test.iso'))

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2621,6 +2621,48 @@ def test_new_in_place_editor_propagates_exceptions(tmpdir):
         with pycdlib.InPlaceEditor(iso_path) as ed:
             ed.modify_file(io.BytesIO(b'x\n'), 2, '/NOPE.;1')
 
+def test_new_in_place_editor_shrinks_across_extent_boundary(tmpdir):
+    # modify_file allows the new content to occupy *fewer* extents
+    # than the old content.  The orphaned extents inside the file's
+    # original allocation are zeroed; the file's data_length on disk
+    # reflects the new (smaller) size.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    # 5000 bytes occupies three 2048-byte extents.
+    iso.add_fp(io.BytesIO(b'A' * 5000), 5000, '/FOO.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    # Shrink the file to 100 bytes (one extent) -- crosses two
+    # extent boundaries downward.
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.modify_file(io.BytesIO(b'b' * 100), 100, '/FOO.;1')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, iso_path='/FOO.;1')
+    assert buf.getvalue() == b'b' * 100
+    iso2.close()
+
+def test_new_in_place_editor_rejects_growing_across_extent_boundary(tmpdir):
+    # Growing across an extent boundary is still rejected -- the
+    # next extent on disk belongs to whatever sits after this file
+    # in the volume layout.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
+            ed.modify_file(io.BytesIO(b'f' * 2049), 2049, '/FOO.;1')
+
 def test_new_pycdlib_modify_file_in_place_warns(tmpdir):
     # PyCdlib.modify_file_in_place is the deprecated method-on-class
     # surface.  Verify it fires the DeprecationWarning that the

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2840,6 +2840,57 @@ def test_new_modify_file_in_place_rewrites_grandparent_after_underflow():
         assert buf.getvalue() == (name + '\n').encode()
     iso3.close()
 
+def test_new_modify_file_in_place_rewrites_subdir_dotdots_after_underflow():
+    # Companion to the grandparent rewrite test.  When _remove_child's
+    # underflow handler shrinks parent.data_length, the in-memory
+    # update also touches each subdirectory's dotdot record (because
+    # dotdot.data_length carries the parent's size).  Those dotdot
+    # records live in their respective subdirectories' own extents,
+    # which modify_file_in_place doesn't otherwise touch.  Without the
+    # subdir-dotdot rewrite, each subdirectory's on-disk dotdot field
+    # is stale -- an internal inconsistency that pedantic ISO9660
+    # validators flag even though no real parser uses dotdot's
+    # data_length for navigation.
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_directory('/PARENT')
+    # SUBDIR is the subdirectory whose on-disk dotdot we'll inspect.
+    iso.add_directory('/PARENT/SUBDIR')
+    # Pack PARENT with enough file children to span two extents.
+    names = [f'F{i:03d}' for i in range(60)]
+    for name in names:
+        iso.add_fp(io.BytesIO((name + '\n').encode()), 5, f'/PARENT/{name}.;1')
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    out.seek(0)
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+    parent = iso2._find_iso_record(b'/PARENT')
+    original_data_length = parent.data_length
+    assert original_data_length > 2048
+    # Remove enough children to trigger _remove_child's underflow,
+    # shrinking PARENT.data_length by one extent.
+    for i in range(50):
+        iso2.rm_file(iso_path=f'/PARENT/F{i:03d}.;1')
+    assert parent.data_length < original_data_length
+    # Modify a remaining sibling.  Without the dotdot rewrite,
+    # PARENT/SUBDIR's on-disk dotdot still claims PARENT.data_length
+    # is the original (larger) value.
+    iso2.modify_file_in_place(io.BytesIO(b'aaa\n'), 4, '/PARENT/F059.;1')
+    iso2.close()
+
+    iso3 = pycdlib.PyCdlib()
+    iso3.open_fp(out)
+    parent3 = iso3._find_iso_record(b'/PARENT')
+    subdir3 = iso3._find_iso_record(b'/PARENT/SUBDIR')
+    # The dotdot (children[1]) is parsed from SUBDIR's on-disk extent;
+    # its data_length should match the parent's actual data_length.
+    assert subdir3.children[1].is_dotdot()
+    assert subdir3.children[1].data_length == parent3.data_length
+    iso3.close()
+
 def test_new_udf_boot_descriptor_parsed():
     # Coverage for the UDF BOOT2 (Boot Descriptor) dispatch in
     # _parse_volume_descriptors.  pycdlib's writer doesn't emit BOOT2 on

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2891,6 +2891,222 @@ def test_new_modify_file_in_place_rewrites_subdir_dotdots_after_underflow():
     assert subdir3.children[1].data_length == parent3.data_length
     iso3.close()
 
+def test_new_update_file_contents_fp_basic():
+    # update_file_contents_fp replaces a file's contents in memory and
+    # the new content lands on disk via the next write_fp() call.
+    # Unlike modify_file_in_place there is no extent-count constraint.
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'original'), 8, '/FOO.;1')
+
+    iso.update_file_contents_fp(io.BytesIO(b'updated content longer than original'), 36,
+                                iso_path='/FOO.;1')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    out.seek(0)
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, iso_path='/FOO.;1')
+    assert buf.getvalue() == b'updated content longer than original'
+    iso2.close()
+
+def test_new_update_file_contents_fp_shorter_content():
+    # Shrinking the content is fine -- write_fp recomputes the layout.
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'A' * 5000), 5000, '/FOO.;1')
+
+    iso.update_file_contents_fp(io.BytesIO(b'tiny'), 4, iso_path='/FOO.;1')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    out.seek(0)
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, iso_path='/FOO.;1')
+    assert buf.getvalue() == b'tiny'
+    iso2.close()
+
+def test_new_update_file_contents_fp_propagates_to_joliet_and_udf():
+    # The shared Inode is what update_file_contents_fp swaps, so every
+    # tree that linked the file (ISO9660 + Joliet + UDF here) sees the
+    # new content automatically.  The caller only specifies one
+    # lookup path.
+    iso = pycdlib.PyCdlib()
+    iso.new(joliet=3, rock_ridge='1.09', udf='2.60')
+    iso.add_fp(io.BytesIO(b'original'), 8, '/FOO.;1', rr_name='foo',
+               joliet_path='/foo', udf_path='/foo')
+
+    iso.update_file_contents_fp(io.BytesIO(b'updated'), 7, iso_path='/FOO.;1')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    out.seek(0)
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+    # Reads via every tree return the new content.
+    for kwargs in ({'iso_path': '/FOO.;1'},
+                   {'rr_path': '/foo'},
+                   {'joliet_path': '/foo'},
+                   {'udf_path': '/foo'}):
+        buf = io.BytesIO()
+        iso2.get_file_from_iso_fp(buf, **kwargs)
+        assert buf.getvalue() == b'updated', f'{kwargs} returned {buf.getvalue()!r}'
+    iso2.close()
+
+def test_new_update_file_contents_via_each_path_kwarg():
+    # Each of iso_path / rr_path / joliet_path / udf_path is a valid
+    # lookup for update_file_contents_fp on an ISO that has all three
+    # extensions.
+    for path_kwarg in ('iso_path', 'rr_path', 'joliet_path', 'udf_path'):
+        iso = pycdlib.PyCdlib()
+        iso.new(joliet=3, rock_ridge='1.09', udf='2.60')
+        iso.add_fp(io.BytesIO(b'before'), 6, '/FOO.;1', rr_name='foo',
+                   joliet_path='/foo', udf_path='/foo')
+        lookup = {'iso_path': '/FOO.;1', 'rr_path': '/foo',
+                  'joliet_path': '/foo', 'udf_path': '/foo'}[path_kwarg]
+        iso.update_file_contents_fp(io.BytesIO(b'after'), 5, **{path_kwarg: lookup})
+
+        out = io.BytesIO()
+        iso.write_fp(out)
+        iso.close()
+
+        out.seek(0)
+        iso2 = pycdlib.PyCdlib()
+        iso2.open_fp(out)
+        buf = io.BytesIO()
+        iso2.get_file_from_iso_fp(buf, iso_path='/FOO.;1')
+        assert buf.getvalue() == b'after'
+        iso2.close()
+
+def test_new_update_file_contents_rejects_no_path():
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'x'), 1, '/FOO.;1')
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+        iso.update_file_contents_fp(io.BytesIO(b'y'), 1)
+    assert 'Exactly one of' in str(excinfo.value)
+    iso.close()
+
+def test_new_update_file_contents_rejects_multiple_paths():
+    iso = pycdlib.PyCdlib()
+    iso.new(joliet=3)
+    iso.add_fp(io.BytesIO(b'x'), 1, '/FOO.;1', joliet_path='/foo')
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+        iso.update_file_contents_fp(io.BytesIO(b'y'), 1,
+                                    iso_path='/FOO.;1', joliet_path='/foo')
+    assert 'Exactly one of' in str(excinfo.value)
+    iso.close()
+
+def test_new_update_file_contents_rejects_directory():
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_directory('/DIR')
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+        iso.update_file_contents_fp(io.BytesIO(b'x'), 1, iso_path='/DIR')
+    assert 'directory' in str(excinfo.value)
+    iso.close()
+
+def test_new_update_file_contents_rejects_symlink():
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.09')
+    iso.add_symlink('/SYM.;1', rr_symlink_name='sym', rr_path='target')
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+        iso.update_file_contents_fp(io.BytesIO(b'x'), 1, iso_path='/SYM.;1')
+    assert 'symlink' in str(excinfo.value)
+    iso.close()
+
+def test_new_update_file_contents_rejects_not_initialized():
+    iso = pycdlib.PyCdlib()
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+        iso.update_file_contents_fp(io.BytesIO(b'x'), 1, iso_path='/FOO.;1')
+    assert 'not initialized' in str(excinfo.value)
+
+def test_new_update_file_contents_filename(tmpdir):
+    # update_file_contents (filename variant) opens the file itself
+    # and manages its lifetime, the same way add_file does relative
+    # to add_fp.
+    src = tmpdir.join('payload')
+    src.write_binary(b'from a real file on disk')
+
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'placeholder'), 11, '/FOO.;1')
+
+    iso.update_file_contents(str(src), iso_path='/FOO.;1')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    out.seek(0)
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, iso_path='/FOO.;1')
+    assert buf.getvalue() == b'from a real file on disk'
+    iso2.close()
+
+def test_new_update_file_contents_composes_with_add_rm_then_write_fp():
+    # The reporter's actual workflow: open, do some mix of add_fp,
+    # rm_file, update_file_contents_fp, then write_fp.
+    # update_file_contents_fp is the supported alternative to
+    # modify_file_in_place for that pattern.
+    iso = pycdlib.PyCdlib()
+    iso.new(joliet=3, rock_ridge='1.09')
+    iso.add_directory('/ISOLINUX', rr_name='isolinux', joliet_path='/isolinux')
+    iso.add_fp(io.BytesIO(b'OLD ISOLINUX CFG'), 16, '/ISOLINUX/ISOLINUX.CFG;1',
+               rr_name='isolinux.cfg', joliet_path='/isolinux/isolinux.cfg')
+    iso.add_fp(io.BytesIO(b'OLD GRUB'), 8, '/ISOLINUX/GRUB.CFG;1',
+               rr_name='grub.cfg', joliet_path='/isolinux/grub.cfg')
+    iso.add_fp(io.BytesIO(b'remove me'), 9, '/ISOLINUX/EXTRA.TXT;1',
+               rr_name='extra.txt', joliet_path='/isolinux/extra.txt')
+
+    seed = io.BytesIO()
+    iso.write_fp(seed)
+    iso.close()
+
+    seed.seek(0)
+    iso = pycdlib.PyCdlib()
+    iso.open_fp(seed)
+    iso.rm_file(iso_path='/ISOLINUX/EXTRA.TXT;1', rr_name='extra.txt',
+                joliet_path='/isolinux/extra.txt')
+    iso.update_file_contents_fp(io.BytesIO(b'NEW ISOLINUX'), 12,
+                                iso_path='/ISOLINUX/ISOLINUX.CFG;1')
+    iso.add_fp(io.BytesIO(b'kickstart'), 9, '/KS.CFG;1',
+               rr_name='ks.cfg', joliet_path='/ks.cfg')
+    iso.update_file_contents_fp(io.BytesIO(b'NEW GRUB'), 8,
+                                joliet_path='/isolinux/grub.cfg')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    out.seek(0)
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+    # The updated, added, and surviving files all read correctly.
+    for path, expected in [('/ISOLINUX/ISOLINUX.CFG;1', b'NEW ISOLINUX'),
+                           ('/ISOLINUX/GRUB.CFG;1',     b'NEW GRUB'),
+                           ('/KS.CFG;1',                b'kickstart')]:
+        buf = io.BytesIO()
+        iso2.get_file_from_iso_fp(buf, iso_path=path)
+        assert buf.getvalue() == expected, f'{path}: {buf.getvalue()!r}'
+    # EXTRA.TXT is gone.
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
+        iso2.get_file_from_iso_fp(io.BytesIO(),
+                                  iso_path='/ISOLINUX/EXTRA.TXT;1')
+    iso2.close()
+
 def test_new_udf_boot_descriptor_parsed():
     # Coverage for the UDF BOOT2 (Boot Descriptor) dispatch in
     # _parse_volume_descriptors.  pycdlib's writer doesn't emit BOOT2 on

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2663,6 +2663,321 @@ def test_new_in_place_editor_rejects_growing_across_extent_boundary(tmpdir):
         with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
             ed.modify_file(io.BytesIO(b'f' * 2049), 2049, '/FOO.;1')
 
+def test_new_in_place_editor_rm_file_basic(tmpdir):
+    # rm_file removes a file from the in-memory tree and commits the
+    # change to disk: the file's directory record is gone from the
+    # parent's extent on disk.  The file's data extent stays as
+    # orphaned bytes inside the volume.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'AAA\n'), 4, '/A.;1')
+    iso.add_fp(io.BytesIO(b'BBB\n'), 4, '/B.;1')
+    iso.add_fp(io.BytesIO(b'CCC\n'), 4, '/C.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.rm_file('/B.;1')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    children = sorted(
+        ch.file_identifier()
+        for ch in iso2.pvd.root_dir_record.children
+        if ch.file_identifier() not in (b'.', b'..')
+    )
+    assert children == [b'A.;1', b'C.;1']
+    # The remaining files still read back correctly.
+    for path, expected in [('/A.;1', b'AAA\n'), ('/C.;1', b'CCC\n')]:
+        buf = io.BytesIO()
+        iso2.get_file_from_iso_fp(buf, iso_path=path)
+        assert buf.getvalue() == expected
+    iso2.close()
+
+def test_new_in_place_editor_rm_file_joliet(tmpdir):
+    # rm_file is Joliet-aware: removing a file removes its record from
+    # both the ISO9660 and Joliet trees.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new(joliet=3)
+    iso.add_fp(io.BytesIO(b'AAA\n'), 4, '/A.;1', joliet_path='/a')
+    iso.add_fp(io.BytesIO(b'BBB\n'), 4, '/B.;1', joliet_path='/b')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.rm_file('/B.;1')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    # Gone from ISO9660 root.
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
+        iso2.get_file_from_iso_fp(io.BytesIO(), iso_path='/B.;1')
+    # Gone from Joliet root too.
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
+        iso2.get_file_from_iso_fp(io.BytesIO(), joliet_path='/b')
+    iso2.close()
+
+def test_new_in_place_editor_rm_file_rejects_directory(tmpdir):
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_directory('/DIR')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
+            ed.rm_file('/DIR')
+
+def test_new_in_place_editor_rm_file_rejects_udf(tmpdir):
+    # UDF in-place rm is out of scope for v1.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new(udf='2.60')
+    iso.add_fp(io.BytesIO(b'foo\n'), 4, '/FOO.;1', udf_path='/foo')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+            ed.rm_file('/FOO.;1')
+        assert 'UDF' in str(excinfo.value)
+
+def test_new_in_place_editor_rm_file_rock_ridge(tmpdir):
+    # rm_file on a Rock Ridge ISO removes the Rock Ridge-bearing
+    # directory record from the parent extent without leaving stale
+    # SUSP bytes behind that would fail re-parse.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.09')
+    iso.add_fp(io.BytesIO(b'AAA\n'), 4, '/A.;1', rr_name='a')
+    iso.add_fp(io.BytesIO(b'BBB\n'), 4, '/B.;1', rr_name='b')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.rm_file('/B.;1')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    children = sorted(
+        ch.file_identifier()
+        for ch in iso2.pvd.root_dir_record.children
+        if ch.file_identifier() not in (b'.', b'..')
+    )
+    assert children == [b'A.;1']
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, rr_path='/a')
+    assert buf.getvalue() == b'AAA\n'
+    iso2.close()
+
+def test_new_in_place_editor_rm_file_rejects_eltorito_boot_file(tmpdir):
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'BOOT' * 512), 2048, '/BOOT.;1')
+    iso.add_eltorito('/BOOT.;1', '/BOOT.CAT;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
+            ed.rm_file('/BOOT.;1')
+
+def test_new_in_place_editor_add_fp_basic(tmpdir):
+    # add_fp appends a new file to the volume and inserts its
+    # directory record into the parent's extent on disk.  The file
+    # is readable from a freshly opened copy of the same ISO file.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'existing\n'), 9, '/EXIST.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.add_fp(io.BytesIO(b'new file contents\n'), 18, '/NEW.;1')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    # Both files are present and read back correctly.
+    for path, expected in [('/EXIST.;1', b'existing\n'),
+                           ('/NEW.;1',   b'new file contents\n')]:
+        buf = io.BytesIO()
+        iso2.get_file_from_iso_fp(buf, iso_path=path)
+        assert buf.getvalue() == expected
+    iso2.close()
+
+def test_new_in_place_editor_add_fp_joliet(tmpdir):
+    # add_fp with joliet_path inserts the record into both the
+    # ISO9660 and Joliet trees.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new(joliet=3)
+    iso.add_fp(io.BytesIO(b'existing\n'), 9, '/EXIST.;1', joliet_path='/exist')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.add_fp(io.BytesIO(b'new\n'), 4, '/NEW.;1', joliet_path='/new')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    for kwargs, expected in [({'iso_path': '/NEW.;1'},     b'new\n'),
+                              ({'joliet_path': '/new'},     b'new\n')]:
+        buf = io.BytesIO()
+        iso2.get_file_from_iso_fp(buf, **kwargs)
+        assert buf.getvalue() == expected
+    iso2.close()
+
+def test_new_in_place_editor_add_file_filename_variant(tmpdir):
+    # The filename variant reads the new content from a file on the
+    # local filesystem (pycdlib manages opening/closing).
+    payload = tmpdir.join('payload')
+    payload.write_binary(b'from disk\n')
+
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'old\n'), 4, '/OLD.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.add_file(str(payload), '/NEW.;1')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, iso_path='/NEW.;1')
+    assert buf.getvalue() == b'from disk\n'
+    iso2.close()
+
+def test_new_in_place_editor_add_fp_rejects_udf(tmpdir):
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new(udf='2.60')
+    iso.add_fp(io.BytesIO(b'old\n'), 4, '/OLD.;1', udf_path='/old')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+            ed.add_fp(io.BytesIO(b'new\n'), 4, '/NEW.;1')
+        assert 'UDF' in str(excinfo.value)
+
+def test_new_in_place_editor_add_fp_rejects_rock_ridge(tmpdir):
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new(rock_ridge='1.09')
+    iso.add_fp(io.BytesIO(b'old\n'), 4, '/OLD.;1', rr_name='old')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+            ed.add_fp(io.BytesIO(b'new\n'), 4, '/NEW.;1')
+        assert 'Rock Ridge' in str(excinfo.value)
+
+def test_new_in_place_editor_add_fp_rejects_eltorito(tmpdir):
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    iso.add_fp(io.BytesIO(b'BOOT' * 512), 2048, '/BOOT.;1')
+    iso.add_eltorito('/BOOT.;1', '/BOOT.CAT;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+            ed.add_fp(io.BytesIO(b'new\n'), 4, '/NEW.;1')
+        assert 'El Torito' in str(excinfo.value)
+
+def test_new_in_place_editor_add_fp_rejects_parent_overflow(tmpdir):
+    # Pack root with enough children that adding one more would
+    # require a new extent.  Verify add_fp refuses cleanly with
+    # "would overflow" messaging.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    # 49 short-name files exactly fill root's one-extent allocation
+    # (under interchange level 1); the 50th forces overflow into a
+    # second extent.  Once written to disk, in-place add can't grow
+    # the parent extent, so adding any file after this point must
+    # refuse.
+    for i in range(49):
+        iso.add_fp(io.BytesIO(b'x'), 1, f'/F{i:03d}.;1')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput) as excinfo:
+            ed.add_fp(io.BytesIO(b'one more\n'), 9, '/ZZZ.;1')
+        assert 'overflow' in str(excinfo.value).lower()
+
+def test_new_in_place_editor_mixed_workflow(tmpdir):
+    # The point of InPlaceEditor: rm_file + modify_file + add_fp can
+    # all be interleaved freely in a single session without the
+    # silent-corruption failure mode that motivated the new class.
+    # This mirrors the reporter's actual workflow on a Fedora-style
+    # boot ISO -- minus the UDF/Rock-Ridge bits that the editor v1
+    # doesn't yet support.
+    iso_path = str(tmpdir.join('test.iso'))
+    iso = pycdlib.PyCdlib()
+    iso.new(joliet=3)
+    iso.add_directory('/IMAGES', joliet_path='/images')
+    iso.add_directory('/EFI', joliet_path='/EFI')
+    iso.add_directory('/EFI/BOOT', joliet_path='/EFI/BOOT')
+    iso.add_fp(io.BytesIO(b'OLD GRUB CFG'), 12, '/EFI/BOOT/GRUB.CFG;1',
+               joliet_path='/EFI/BOOT/grub.cfg')
+    iso.add_fp(io.BytesIO(b'install image bytes'), 19, '/IMAGES/INSTALL.IMG;1',
+               joliet_path='/images/install.img')
+    with open(iso_path, 'wb') as f:
+        iso.write_fp(f)
+    iso.close()
+
+    with pycdlib.InPlaceEditor(iso_path) as ed:
+        ed.rm_file('/IMAGES/INSTALL.IMG;1')
+        ed.modify_file(io.BytesIO(b'NEW GRUB CFG'), 12, '/EFI/BOOT/GRUB.CFG;1')
+        ed.add_fp(io.BytesIO(b'kickstart payload'), 17, '/KS.CFG;1',
+                  joliet_path='/ks.cfg')
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open(iso_path)
+    # GRUB.CFG has the new content.
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, iso_path='/EFI/BOOT/GRUB.CFG;1')
+    assert buf.getvalue() == b'NEW GRUB CFG'
+    # KS.CFG was added.
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, iso_path='/KS.CFG;1')
+    assert buf.getvalue() == b'kickstart payload'
+    # Via Joliet too.
+    buf = io.BytesIO()
+    iso2.get_file_from_iso_fp(buf, joliet_path='/ks.cfg')
+    assert buf.getvalue() == b'kickstart payload'
+    # INSTALL.IMG is gone from both trees.
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
+        iso2.get_file_from_iso_fp(io.BytesIO(), iso_path='/IMAGES/INSTALL.IMG;1')
+    with pytest.raises(pycdlib.pycdlibexception.PyCdlibInvalidInput):
+        iso2.get_file_from_iso_fp(io.BytesIO(), joliet_path='/images/install.img')
+    iso2.close()
+
 def test_new_pycdlib_modify_file_in_place_warns(tmpdir):
     # PyCdlib.modify_file_in_place is the deprecated method-on-class
     # surface.  Verify it fires the DeprecationWarning that the

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -3926,6 +3926,7 @@ def test_new_rm_joliet_hard_link():
 
     iso.close()
 
+@uses_deprecated("add_joliet_directory")
 def test_new_add_joliet_directory_not_initialized():
     # Create a new ISO.
     iso = pycdlib.PyCdlib()
@@ -3934,6 +3935,7 @@ def test_new_add_joliet_directory_not_initialized():
         iso.add_joliet_directory('/foo')
     assert(str(excinfo.value) == 'This object is not initialized; call either open() or new() to create an ISO')
 
+@uses_deprecated("add_joliet_directory")
 def test_new_add_joliet_directory():
     # Create a new ISO.
     iso = pycdlib.PyCdlib()
@@ -3946,6 +3948,7 @@ def test_new_add_joliet_directory():
 
     iso.close()
 
+@uses_deprecated("add_joliet_directory")
 def test_new_add_joliet_directory_isolevel4():
     # Create a new ISO.
     iso = pycdlib.PyCdlib()
@@ -3961,6 +3964,7 @@ def test_new_add_joliet_directory_isolevel4():
 
     iso.close()
 
+@uses_deprecated("add_joliet_directory")
 def test_new_add_joliet_directory_always_consistent():
     # Create a new ISO.
     iso = pycdlib.PyCdlib(always_consistent=True)
@@ -3973,6 +3977,7 @@ def test_new_add_joliet_directory_always_consistent():
 
     iso.close()
 
+@uses_deprecated("rm_joliet_directory")
 def test_new_rm_joliet_directory():
     # Create a new ISO.
     iso = pycdlib.PyCdlib()
@@ -3987,6 +3992,7 @@ def test_new_rm_joliet_directory():
 
     iso.close()
 
+@uses_deprecated("rm_joliet_directory")
 def test_new_rm_joliet_directory_not_initialized():
     # Create a new ISO.
     iso = pycdlib.PyCdlib()
@@ -3995,6 +4001,7 @@ def test_new_rm_joliet_directory_not_initialized():
         iso.rm_joliet_directory('/dir1')
     assert(str(excinfo.value) == 'This object is not initialized; call either open() or new() to create an ISO')
 
+@uses_deprecated("rm_joliet_directory")
 def test_new_rm_joliet_directory_always_consistent():
     # Create a new ISO.
     iso = pycdlib.PyCdlib(always_consistent=True)
@@ -4009,6 +4016,7 @@ def test_new_rm_joliet_directory_always_consistent():
 
     iso.close()
 
+@uses_deprecated("rm_joliet_directory")
 def test_new_rm_joliet_directory_iso_level4():
     # Create a new ISO.
     iso = pycdlib.PyCdlib()
@@ -4165,6 +4173,7 @@ def test_new_rm_directory_no_path():
 
     iso.close()
 
+@uses_deprecated("add_joliet_directory")
 def test_new_rm_directory_joliet_only():
     # Create a new ISO.
     iso = pycdlib.PyCdlib()
@@ -4177,6 +4186,7 @@ def test_new_rm_directory_joliet_only():
 
     iso.close()
 
+@uses_deprecated("get_and_write_fp")
 def test_new_get_and_write_dir():
     iso = pycdlib.PyCdlib()
     iso.new()
@@ -4190,6 +4200,7 @@ def test_new_get_and_write_dir():
 
     iso.close()
 
+@uses_deprecated("get_and_write_fp")
 def test_new_get_and_write_joliet():
     iso = pycdlib.PyCdlib()
     iso.new(joliet=3)
@@ -4204,6 +4215,7 @@ def test_new_get_and_write_joliet():
 
     iso.close()
 
+@uses_deprecated("get_and_write_fp")
 def test_new_get_and_write_iso9660():
     iso = pycdlib.PyCdlib()
     iso.new(joliet=3)
@@ -4218,6 +4230,7 @@ def test_new_get_and_write_iso9660():
 
     iso.close()
 
+@uses_deprecated("get_and_write_fp")
 def test_new_get_and_write_rr():
     iso = pycdlib.PyCdlib()
     iso.new(rock_ridge='1.09')
@@ -4232,6 +4245,7 @@ def test_new_get_and_write_rr():
 
     iso.close()
 
+@uses_deprecated("get_and_write_fp")
 def test_new_get_and_write_iso9660_no_rr():
     iso = pycdlib.PyCdlib()
     iso.new()
@@ -4481,6 +4495,7 @@ def test_new_list_children():
 
     iso.close()
 
+@uses_deprecated("list_dir")
 def test_new_list_dir_joliet():
     # Create a new ISO.
     iso = pycdlib.PyCdlib()

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -2620,6 +2620,157 @@ def test_new_modify_file_in_place_unsorted_dir_records():
         assert(buf.getvalue() == expected)
     iso3.close()
 
+def test_new_rewrite_dir_record_extent_pads_after_rm():
+    # Regression test for the zero-padding bug in
+    # _rewrite_dir_record_extent.  Before the fix, the function wrote
+    # the in-memory children list consecutively into the parent's
+    # directory extent on disk but did not clear bytes past the new
+    # last record.  After rm_file + modify_file_in_place in the same
+    # parent, the post-rewrite extent retained the trailing bytes of
+    # the removed record, which either failed the parser's
+    # zero-padding check ("Invalid padding on ISO") or produced a
+    # phantom record.
+    #
+    # Build a directory with several siblings, rm one, modify another,
+    # then verify the ISO re-parses cleanly and the rm and modify both
+    # took effect.
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    for name in ('AAA', 'BBB', 'CCC', 'DDD', 'EEE'):
+        iso.add_fp(io.BytesIO((name + '\n').encode()), 4, f'/{name}.;1')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    out.seek(0)
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+    iso2.rm_file(iso_path='/CCC.;1')
+    iso2.modify_file_in_place(io.BytesIO(b'aaa\n'), 4, '/AAA.;1')
+    iso2.close()
+
+    # Reopen and verify the ISO is well-formed.  Without the zero-pad
+    # fix, this raises "Invalid padding on ISO".
+    iso3 = pycdlib.PyCdlib()
+    iso3.open_fp(out)
+    # All remaining files should be present and rm'd file should be
+    # absent.  Without the fix, a phantom record could synthesize an
+    # unexpected entry here.
+    children = sorted(
+        ch.file_identifier()
+        for ch in iso3.pvd.root_dir_record.children
+        if ch.file_identifier() not in (b'.', b'..')
+    )
+    assert children == [b'AAA.;1', b'BBB.;1', b'DDD.;1', b'EEE.;1']
+    for path, expected in [('/AAA.;1', b'aaa\n'),
+                           ('/BBB.;1', b'BBB\n'),
+                           ('/DDD.;1', b'DDD\n'),
+                           ('/EEE.;1', b'EEE\n')]:
+        buf = io.BytesIO()
+        iso3.get_file_from_iso_fp(buf, iso_path=path)
+        assert(buf.getvalue() == expected)
+    iso3.close()
+
+def test_new_rewrite_dir_record_extent_pads_after_rm_multi_extent():
+    # Same as the previous test but with a parent directory whose
+    # children span multiple extents.  The rm is small enough that the
+    # in-memory layout still occupies the same number of extents (i.e.,
+    # data_length does not shrink), so the parser still expects to read
+    # the full multi-extent span.  Without the zero-pad fix, the
+    # trailing bytes of the last extent the rewrite touches contain
+    # stale bytes from the removed record.
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    # Each record at level-1 is roughly 40+ bytes with Rock Ridge off;
+    # 60 children of similar names easily spill into a second extent.
+    names = [f'F{i:03d}' for i in range(60)]
+    for name in names:
+        iso.add_fp(io.BytesIO((name + '\n').encode()), 5, f'/{name}.;1')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    out.seek(0)
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+    # Confirm the parent really does span >1 extent on disk.
+    assert iso2.pvd.root_dir_record.data_length > 2048
+    # Remove a child from the middle of the sort order and modify
+    # another sibling.  The rewrite covers all of the original
+    # data_length span, so the bug surfaces in whichever extent the
+    # new last record lands in.
+    iso2.rm_file(iso_path='/F030.;1')
+    iso2.modify_file_in_place(io.BytesIO(b'aaa\n'), 4, '/F000.;1')
+    iso2.close()
+
+    iso3 = pycdlib.PyCdlib()
+    iso3.open_fp(out)
+    children = sorted(
+        ch.file_identifier()
+        for ch in iso3.pvd.root_dir_record.children
+        if ch.file_identifier() not in (b'.', b'..')
+    )
+    expected = sorted(f'{name}.;1'.encode() for name in names if name != 'F030')
+    assert children == expected
+    # Spot-check the modified file and a few unmodified ones.
+    buf = io.BytesIO()
+    iso3.get_file_from_iso_fp(buf, iso_path='/F000.;1')
+    assert buf.getvalue() == b'aaa\n'
+    for name in ('F001', 'F029', 'F031', 'F059'):
+        buf = io.BytesIO()
+        iso3.get_file_from_iso_fp(buf, iso_path=f'/{name}.;1')
+        assert buf.getvalue() == (name + '\n').encode()
+    iso3.close()
+
+def test_new_rewrite_dir_record_extent_pads_across_extent_transition():
+    # When _rewrite_dir_record_extent's serialized children pack
+    # differently than the on-disk layout (e.g., because a child was
+    # removed), the loop advances to a new extent partway through.
+    # Without the fix, the trailing bytes of the previous extent are
+    # left holding stale bytes from the on-disk layout.  This test
+    # exercises that intermediate-extent-transition case specifically:
+    # by removing an early-sorting child, the loop's transition point
+    # shifts and the trailing bytes of the first extent must be
+    # zero-padded.
+    iso = pycdlib.PyCdlib()
+    iso.new()
+    # Roughly 60 same-length children to span 2 extents; the rm of the
+    # first one shifts where the loop transitions to extent 2.
+    names = [f'F{i:03d}' for i in range(60)]
+    for name in names:
+        iso.add_fp(io.BytesIO((name + '\n').encode()), 5, f'/{name}.;1')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    out.seek(0)
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+    assert iso2.pvd.root_dir_record.data_length > 2048
+    # Remove the first sortable child (after dot/dotdot) so every
+    # subsequent record shifts to a lower byte offset, including the
+    # boundary that decides which extent each record lands in.
+    iso2.rm_file(iso_path='/F000.;1')
+    iso2.modify_file_in_place(io.BytesIO(b'aaa\n'), 4, '/F059.;1')
+    iso2.close()
+
+    iso3 = pycdlib.PyCdlib()
+    iso3.open_fp(out)
+    children = sorted(
+        ch.file_identifier()
+        for ch in iso3.pvd.root_dir_record.children
+        if ch.file_identifier() not in (b'.', b'..')
+    )
+    expected = sorted(f'{name}.;1'.encode() for name in names if name != 'F000')
+    assert children == expected
+    buf = io.BytesIO()
+    iso3.get_file_from_iso_fp(buf, iso_path='/F059.;1')
+    assert buf.getvalue() == b'aaa\n'
+    iso3.close()
+
 def test_new_udf_boot_descriptor_parsed():
     # Coverage for the UDF BOOT2 (Boot Descriptor) dispatch in
     # _parse_volume_descriptors.  pycdlib's writer doesn't emit BOOT2 on

--- a/tests/integration/test_parse.py
+++ b/tests/integration/test_parse.py
@@ -993,6 +993,7 @@ def test_parse_open_twice(tmpdir):
 
     iso.close()
 
+@uses_deprecated("get_and_write_fp")
 def test_parse_get_and_write_fp_not_initialized(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('modifyinplaceisolevel4onefile')
@@ -1008,6 +1009,7 @@ def test_parse_get_and_write_fp_not_initialized(tmpdir):
         iso.get_and_write_fp('/FOO.;1', open(os.path.join(str(tmpdir), 'bar'), 'w'))
     assert(str(excinfo.value) == 'This object is not initialized; call either open() or new() to create an ISO')
 
+@uses_deprecated("get_and_write")
 def test_parse_get_and_write_not_initialized(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('modifyinplaceisolevel4onefile')
@@ -1093,6 +1095,7 @@ def test_parse_write_with_progress_three_arg(tmpdir):
 
     iso.close()
 
+@uses_deprecated("get_entry")
 def test_parse_get_entry(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('twofile')
@@ -1118,6 +1121,7 @@ def test_parse_get_entry(tmpdir):
 
     iso.close()
 
+@uses_deprecated("get_entry")
 def test_parse_get_entry_not_initialized(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('twofile')
@@ -1134,6 +1138,7 @@ def test_parse_get_entry_not_initialized(tmpdir):
         fooentry = iso.get_entry('/FOO.;1')
     assert(str(excinfo.value) == 'This object is not initialized; call either open() or new() to create an ISO')
 
+@uses_deprecated("list_dir")
 def test_parse_list_dir(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('twofile')
@@ -1153,6 +1158,7 @@ def test_parse_list_dir(tmpdir):
 
     iso.close()
 
+@uses_deprecated("list_dir")
 def test_parse_list_dir_not_initialized(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('twofile')
@@ -1171,6 +1177,7 @@ def test_parse_list_dir_not_initialized(tmpdir):
             pass
     assert(str(excinfo.value) == 'This object is not initialized; call either open() or new() to create an ISO')
 
+@uses_deprecated("list_dir")
 def test_parse_list_dir_not_dir(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('twofile')
@@ -1192,6 +1199,7 @@ def test_parse_list_dir_not_dir(tmpdir):
 
     iso.close()
 
+@uses_deprecated("get_and_write")
 def test_parse_get_and_write(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('modifyinplaceisolevel4onefile')
@@ -1945,6 +1953,7 @@ def test_parse_eltorito_hide_boot(tmpdir):
 
     do_a_test(tmpdir, outfile, check_eltorito_hide_boot)
 
+@uses_deprecated("get_entry")
 def test_parse_get_entry_joliet(tmpdir):
     # First set things up, and generate the ISO with genisoimage.
     indir = tmpdir.mkdir('getentryjoliet')


### PR DESCRIPTION
After heavy debugging on #171 , I've come to the conclusion that the APIs around updating data are incorrect.  In particular, it is too easy to misuse `modify_file_in_place` when using the other APIs.  Thus this PR does the following:

1.  Zero-pads directory records.  This is mostly a bug-fix for when a record shrinks.
2.  Makes sure to propagate directory record shrinks all the way to the root.  Again, a bug fix for when a directory record shrinks so all parents, grandparents, etc also get shrunken appropriately.
3.  Update the dotdot data length for `modify_file_in_place`.  Again a bug fix to make sure dotdot length is always correct.
4.  Emit `DeprecationWarning` from actually deprecated APIs.
5.  Add a new API to the main PyCdlib class called `update_file_contents`.  This allows the user to update file contents, ready for mastering.  This was technically possible before by calling a `rm_file` followed by an `add_file` with the same filename and new contents, but this is more ergonomic.
6.  Add in a completely new contextmanager class called `InPlaceEditor`, which allows modifying things in place.  This is the new API users should use if they want to modify in place.  Also in here, I've deprecated `modify_file_in_place` from the main `PyCdlib` class.