### PR TITLE
Ensure we can remove El Torito from a Windows 11 ISO.

### DIFF
--- a/pycdlib/pycdlib.py
+++ b/pycdlib/pycdlib.py
@@ -5667,6 +5667,15 @@ class PyCdlib:
         # the Boot Catalog.
         for rec in self.eltorito_boot_catalog.dirrecords:
             if isinstance(rec, dr.DirectoryRecord):
+                if rec.index_in_parent < 0:
+                    # A parse-time stand-in for a hidden boot catalog (see
+                    # _walk_directories); it was never added to its parent's
+                    # children and exists nowhere on the ISO, so there is
+                    # nothing to remove.  It must not carry an inode; if it
+                    # ever did, skipping it here would leak the inode linkage.
+                    if rec.inode is not None:
+                        raise pycdlibexception.PyCdlibInternalError('Hidden El Torito boot catalog record unexpectedly has an inode')
+                    continue
                 num_bytes_to_remove += self._rm_dr_link(rec)
             elif isinstance(rec, udfmod.UDFFileEntry):
                 num_bytes_to_remove += self._rm_udf_link(rec)

--- a/tests/integration/test_new.py
+++ b/tests/integration/test_new.py
@@ -8513,3 +8513,33 @@ def test_new_get_file_byte_extents_directory():
         iso.get_file_byte_extents(iso_path='/DIR1')
     assert(str(excinfo.value) == 'Cannot get extents for a directory')
     iso.close()
+
+def test_new_rm_eltorito_hidden_boot_catalog():
+    # Regression test for https://github.com/clalancette/pycdlib/issues/175;
+    # an ISO whose El Torito boot catalog has no directory record (like
+    # Microsoft Windows installation ISOs) gets a 'fake' directory record
+    # during parsing, and rm_eltorito used to fail on it with
+    # 'Invalid child index to remove'.
+    iso = pycdlib.PyCdlib()
+    iso.new()
+
+    bootstr = b'boot\n'
+    iso.add_fp(io.BytesIO(bootstr), len(bootstr), '/BOOT.;1')
+    iso.add_eltorito('/BOOT.;1', '/BOOT.CAT;1')
+
+    # Hide the boot catalog so it has no directory record on the ISO.
+    iso.rm_hard_link(iso_path='/BOOT.CAT;1')
+
+    out = io.BytesIO()
+    iso.write_fp(out)
+    iso.close()
+
+    iso2 = pycdlib.PyCdlib()
+    iso2.open_fp(out)
+
+    iso2.rm_eltorito()
+    iso2.rm_file('/BOOT.;1')
+
+    do_a_test(iso2, check_nofiles)
+
+    iso2.close()


### PR DESCRIPTION
The problem was that the El Torito boot catalog on the Windows 11 ISO did not have any records attached.  While this violates the standard, it is a relatively common situation, so we attach a "fake" directory record so that the ISO is conformant.

But we forgot to propogate that fix through to rm_eltorito, so if you try to remove El Torito on such an ISO, you can an exception rather than successful removal.  The fix is to skip this fake record on such ISOs.

This fixes #175 